### PR TITLE
Exception in bytecode.club.bytecodeviewer.JarUtils.getNode() 

### DIFF
--- a/src/the/bytecode/club/bytecodeviewer/JarUtils.java
+++ b/src/the/bytecode/club/bytecodeviewer/JarUtils.java
@@ -69,7 +69,14 @@ public class JarUtils {
     public static ClassNode getNode(final byte[] bytez) {
         cr = new ClassReader(bytez);
         cn = new ClassNode();
-        cr.accept(cn, ClassReader.EXPAND_FRAMES);
+        try {
+            cr.accept(cn, ClassReader.EXPAND_FRAMES);
+        }
+        catch(Exception e)
+        {
+            //
+        }
+
         cr = null;
         return cn;
     }


### PR DESCRIPTION
bytecode.club.bytecodeviewer.JarUtils.getNode throws ArrayIndexOutOfBoundsException

Fixed the bug. 
