### PR TITLE
[squid:S2095] Resources should be closed

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/JarUtils.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/JarUtils.java
@@ -192,9 +192,9 @@ public class JarUtils {
 	 */
 	public static void saveAsJar(ArrayList<ClassNode> nodeList, String path,
 			String manifest) {
-		try {
-			JarOutputStream out = new JarOutputStream(
-					new FileOutputStream(path));
+		try (JarOutputStream out = new JarOutputStream(
+				new FileOutputStream(path))) {
+			
 			for (ClassNode cn : nodeList) {
 				ClassWriter cw = new ClassWriter(0);
 				cn.accept(cw);
@@ -218,7 +218,6 @@ public class JarUtils {
 					}
 				}
 
-			out.close();
 		} catch (IOException e) {
 			new the.bytecode.club.bytecodeviewer.api.ExceptionUI(e);
 		}
@@ -230,8 +229,7 @@ public class JarUtils {
 	 * @param path the exact jar output path
 	 */
 	public static void saveAsJarClassesOnly(ArrayList<ClassNode> nodeList, String path) {
-		try {
-			JarOutputStream out = new JarOutputStream(new FileOutputStream(path));
+		try (JarOutputStream out = new JarOutputStream(new FileOutputStream(path))) {
 			ArrayList<String> noDupe = new ArrayList<String>();
 			for (ClassNode cn : nodeList) {
 				ClassWriter cw = new ClassWriter(0);
@@ -248,15 +246,13 @@ public class JarUtils {
 			}
 
 			noDupe.clear();
-			out.close();
 		} catch (IOException e) {
 			new the.bytecode.club.bytecodeviewer.api.ExceptionUI(e);
 		}
 	}
 
 	public static void saveAsJarClassesOnly(Map<String, byte[]> nodeList, String path) {
-		try {
-			JarOutputStream out = new JarOutputStream(new FileOutputStream(path));
+		try (JarOutputStream out = new JarOutputStream(new FileOutputStream(path))) {
 			ArrayList<String> noDupe = new ArrayList<String>();
 			for (Entry<String, byte[]> cn : nodeList.entrySet()) {
 				String name = cn.getKey();
@@ -269,15 +265,13 @@ public class JarUtils {
 			}
 
 			noDupe.clear();
-			out.close();
 		} catch (IOException e) {
 			new the.bytecode.club.bytecodeviewer.api.ExceptionUI(e);
 		}
 	}
 
 	public static void saveAsJar(Map<String, byte[]> nodeList, String path) {
-		try {
-			JarOutputStream out = new JarOutputStream(new FileOutputStream(path));
+		try (JarOutputStream out = new JarOutputStream(new FileOutputStream(path))) {
 			ArrayList<String> noDupe = new ArrayList<String>();
 			for (Entry<String, byte[]> entry : nodeList.entrySet()) {
 				String name = entry.getKey();
@@ -303,7 +297,6 @@ public class JarUtils {
 				}
 
 			noDupe.clear();
-			out.close();
 		} catch (IOException e) {
 			new the.bytecode.club.bytecodeviewer.api.ExceptionUI(e);
 		}

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/JDGUIDecompiler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/JDGUIDecompiler.java
@@ -60,9 +60,9 @@ public class JDGUIDecompiler extends Decompiler {
 
     @Override
     public void decompileToZip(String zipName) {
-        try {
-            File output = new File(zipName);
-            ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(output));
+        File output = new File(zipName);
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(output))) {
+            
             for (Map.Entry<String, byte[]> entry : BytecodeViewer.getLoadedBytes().entrySet()) {
                 String name = entry.getKey();
                 if (name.endsWith(".class")) {
@@ -82,7 +82,6 @@ public class JDGUIDecompiler extends Decompiler {
                 }
                 zipOutputStream.closeEntry();
             }
-            zipOutputStream.close();
         } catch (Exception e) {
             handleException(e);
         }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/bytecode/InstructionPrinter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/bytecode/InstructionPrinter.java
@@ -291,13 +291,11 @@ public class InstructionPrinter {
     }
 
     public static void saveTo(File file, InstructionPrinter printer) {
-        try {
-            BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
             for (String s : printer.createPrint()) {
                 bw.write(s);
                 bw.newLine();
             }
-            bw.close();
         } catch (IOException e) {
             new the.bytecode.club.bytecodeviewer.api.ExceptionUI(e);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Abdelghany.