### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/jd/cli/util/ClassFileUtil.java
+++ b/src/main/java/jd/cli/util/ClassFileUtil.java
@@ -12,10 +12,13 @@ import java.io.*;
 
 
 public class ClassFileUtil {
+    private ClassFileUtil() {
+    }
+
     /*
-     * Lecture rapide de la structure de la classe et extraction du nom du
-     * repoertoire de base.
-     */
+         * Lecture rapide de la structure de la classe et extraction du nom du
+         * repoertoire de base.
+         */
     public static String ExtractDirectoryPath(String pathToClass) throws Exception {
         DataInputStream dis = null;
         String directoryPath = null;

--- a/src/main/java/jd/cli/util/CommonTypeNameUtil.java
+++ b/src/main/java/jd/cli/util/CommonTypeNameUtil.java
@@ -4,6 +4,9 @@ import jd.core.util.TypeNameUtil;
 
 public class CommonTypeNameUtil 
 {
+	private CommonTypeNameUtil() {
+	}
+
 	public static String InternalPathToQualifiedTypeName(String internalPath)
 	{
 		String internalTypeName = internalPath.substring(0, internalPath.length()-6);

--- a/src/main/java/jd/cli/util/VersionUtil.java
+++ b/src/main/java/jd/cli/util/VersionUtil.java
@@ -2,6 +2,9 @@ package jd.cli.util;
 
 public class VersionUtil 
 {
+	private VersionUtil() {
+	}
+
 	public static String getJDKVersion(int majorVersion, int minorVersion)
 	{
 		StringBuffer sb = new StringBuffer(20);

--- a/src/main/java/org/apache/commons/cli/OptionValidator.java
+++ b/src/main/java/org/apache/commons/cli/OptionValidator.java
@@ -25,6 +25,9 @@ package org.apache.commons.cli;
  */
 final class OptionValidator
 {
+    private OptionValidator() {
+    }
+
     /**
      * Validates whether <code>opt</code> is a permissible Option
      * shortOpt.  The rules that specify if the <code>opt</code>

--- a/src/main/java/org/apache/commons/cli/PatternOptionBuilder.java
+++ b/src/main/java/org/apache/commons/cli/PatternOptionBuilder.java
@@ -87,6 +87,9 @@ public class PatternOptionBuilder
     /** URL class */
     public static final Class<URL> URL_VALUE = URL.class;
 
+    private PatternOptionBuilder() {
+    }
+
     /**
      * Retrieve the class that <code>ch</code> represents.
      *

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -32,6 +32,9 @@ import java.util.Date;
  */
 public class TypeHandler
 {
+    private TypeHandler() {
+    }
+
     /**
      * Returns the <code>Object</code> of type <code>obj</code>
      * with the value of <code>str</code>.

--- a/src/main/java/org/apache/commons/cli/Util.java
+++ b/src/main/java/org/apache/commons/cli/Util.java
@@ -24,6 +24,9 @@ package org.apache.commons.cli;
  */
 final class Util
 {
+    private Util() {
+    }
+
     /**
      * Remove the hyphens from the beginning of <code>str</code> and
      * return the new String.

--- a/src/main/java/org/apache/commons/codec/binary/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/codec/binary/CharSequenceUtils.java
@@ -29,6 +29,9 @@ package org.apache.commons.codec.binary;
  */
 public class CharSequenceUtils {
 
+    private CharSequenceUtils() {
+    }
+
     /**
      * Green implementation of regionMatches.
      *

--- a/src/main/java/org/apache/commons/codec/binary/StringUtils.java
+++ b/src/main/java/org/apache/commons/codec/binary/StringUtils.java
@@ -38,6 +38,9 @@ import java.nio.charset.Charset;
  */
 public class StringUtils {
 
+    private StringUtils() {
+    }
+
     /**
      * <p>
      * Compares two CharSequences, returning <code>true</code> if they represent equal sequences of characters.

--- a/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
@@ -36,6 +36,9 @@ public class DigestUtils {
 
     private static final int STREAM_BUFFER_LENGTH = 1024;
 
+    private DigestUtils() {
+    }
+
     /**
      * Read through an ByteBuffer and returns the digest for the data
      *

--- a/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
@@ -44,6 +44,9 @@ public final class HmacUtils {
 
     private static final int STREAM_BUFFER_LENGTH = 1024;
 
+    private HmacUtils() {
+    }
+
     /**
      * Returns an initialized <code>Mac</code> for the HmacMD5 algorithm.
      * <p>

--- a/src/main/java/org/apache/commons/codec/language/SoundexUtils.java
+++ b/src/main/java/org/apache/commons/codec/language/SoundexUtils.java
@@ -30,6 +30,9 @@ import org.apache.commons.codec.StringEncoder;
  */
 final class SoundexUtils {
 
+    private SoundexUtils() {
+    }
+
     /**
      * Cleans up the input string before Soundex processing by only returning
      * upper case letters.

--- a/src/main/java/org/apache/commons/codec/net/Utils.java
+++ b/src/main/java/org/apache/commons/codec/net/Utils.java
@@ -29,6 +29,9 @@ import org.apache.commons.codec.DecoderException;
  */
 class Utils {
 
+    private Utils() {
+    }
+
     /**
      * Returns the numeric value of the character <code>b</code> in radix 16.
      *

--- a/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
@@ -141,6 +141,9 @@ public class BytecodeViewer {
     public static boolean pingback = false;
     public static boolean deleteForiegnLibraries = true;
 
+    private BytecodeViewer() {
+    }
+
     /**
      * Main startup
      *

--- a/src/main/java/the/bytecode/club/bytecodeviewer/JarUtils.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/JarUtils.java
@@ -41,6 +41,9 @@ import java.util.zip.ZipInputStream;
 
 public class JarUtils {
 
+	private JarUtils() {
+	}
+
 	/**
 	 * Loads the classes and resources from the input jar file
 	 * @param jarFile the input jar file

--- a/src/main/java/the/bytecode/club/bytecodeviewer/MiscUtils.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/MiscUtils.java
@@ -36,6 +36,9 @@ public class MiscUtils {
 	private static final String AN = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 	private static Random rnd = new Random();
 
+	private MiscUtils() {
+	}
+
 	/**
 	 * Returns a random string without numbers
 	 * @param len the length of the String

--- a/src/main/java/the/bytecode/club/bytecodeviewer/api/BytecodeViewer.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/api/BytecodeViewer.java
@@ -45,6 +45,9 @@ public class BytecodeViewer {
 
     private static URLClassLoader cl;
 
+    private BytecodeViewer() {
+    }
+
     /**
      * Grab the loader instance
      *

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/bytecode/FieldNodeDecompiler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/bytecode/FieldNodeDecompiler.java
@@ -34,8 +34,11 @@ import java.util.List;
 
 public class FieldNodeDecompiler {
 
+	private FieldNodeDecompiler() {
+	}
+
 	public static PrefixedStringBuilder decompile(PrefixedStringBuilder sb,
-			FieldNode f) {
+												  FieldNode f) {
 		String s = getAccessString(f.access);
 		sb.append(s);
 		if (s.length() > 0)

--- a/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginManager.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginManager.java
@@ -61,7 +61,10 @@ public final class PluginManager {
 		launchStrategies.put("rb", ruby);
 		launchStrategies.put("ruby", ruby);
 	}
-	
+
+	private PluginManager() {
+	}
+
 	/**
 	 * Runs a new plugin instance
 	 * @param newPluginInstance the new plugin instance


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.