### PR TITLE
Fixed NPE with fat Jar and clean working folder

### DIFF
--- a/src/the/bytecode/club/bootloader/Boot.java
+++ b/src/the/bytecode/club/bootloader/Boot.java
@@ -323,7 +323,7 @@ public class Boot {
     }
 
     public static void populateLibsDirectory() {
-        if (libsDir() != null)
+        if (libsDir() != null && libsDir().exists())
             for (File f : libsDir().listFiles()) {
                 libsList.add(f.getName());
                 libsFileList.add(f.getAbsolutePath());


### PR DESCRIPTION
java.lang.NullPointerException
	at the.bytecode.club.bootloader.Boot.populateLibsDirectory(Boot.java:327)
	at the.bytecode.club.bytecodeviewer.BytecodeViewer$3.run(BytecodeViewer.java:408)

This prevented at least Krakatau from working, because further
initialization in BytecodeViewer$3.run was inhibited.