### PR TITLE
Fixed dex2jar with filenames containing dex or apk

### DIFF
--- a/src/the/bytecode/club/bytecodeviewer/Dex2Jar.java
+++ b/src/the/bytecode/club/bytecodeviewer/Dex2Jar.java
@@ -37,7 +37,7 @@ public class Dex2Jar {
     public static synchronized void dex2Jar(File input, File output) {
         try {
             com.googlecode.dex2jar.tools.Dex2jarCmd.main(new String[]{input.getAbsolutePath()});
-            String realOutput = input.getName().replaceAll(".dex", "-dex2jar.jar").replaceAll(".apk", "-dex2jar.jar");
+            String realOutput = input.getName().replaceAll("\\.dex", "-dex2jar.jar").replaceAll("\\.apk", "-dex2jar.jar");
             File realOutputF = new File(realOutput);
             realOutputF.renameTo(output);
             File realOutputF2 = new File(realOutput);
@@ -57,7 +57,7 @@ public class Dex2Jar {
     public static synchronized void saveAsDex(File input, File output) {
         try {
             com.googlecode.dex2jar.tools.Jar2Dex.main(new String[]{input.getAbsolutePath()});
-            String realOutput = input.getName().replaceAll(".jar", "-jar2dex.dex");
+            String realOutput = input.getName().replaceAll("\\.jar", "-jar2dex.dex");
             File realOutputF = new File(realOutput);
             realOutputF.renameTo(output);
             File realOutputF2 = new File(realOutput);


### PR DESCRIPTION
Existing code did not work with .apk files, which contained "apk" substring in the filename.