### PR TITLE
Properly create .Bytecode-Viewer/libs if it doesn't exist

### DIFF
--- a/src/the/bytecode/club/bootloader/Boot.java
+++ b/src/the/bytecode/club/bootloader/Boot.java
@@ -285,11 +285,11 @@ public class Boot {
     }
 
     public static File libsDir() {
-        File dir = new File(System.getProperty("user.home"), ".Bytecode-Viewer");
+        File dir = new File(System.getProperty("user.home"), ".Bytecode-Viewer/libs");
         while (!dir.exists())
             dir.mkdirs();
 
-        return new File(dir, "libs");
+        return dir;
     }
 
     public static void setState(String s) {


### PR DESCRIPTION
Without this it can fail to download krakatau or enjarify on machines without an already existing `.Bytecode-Viewer`