### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,16 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-        <repository>
             <id>local-maven-repo</id>
             <url>file:///${project.basedir}/libs</url>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository> <!-- TODO Remove when DarkLaf is properly updated -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -37,27 +41,27 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>9.1</version>
+            <version>9.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-analysis</artifactId>
-            <version>9.1</version>
+            <version>9.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>9.1</version>
+            <version>9.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>9.1</version>
+            <version>9.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-util</artifactId>
-            <version>9.1</version>
+            <version>9.2</version>
         </dependency>
         <dependency>
             <groupId>org.benf</groupId>
@@ -82,17 +86,17 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>commons-compiler</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -127,7 +131,7 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.jd</groupId>
@@ -192,7 +196,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.28</version>
+            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>xpp3</groupId>
@@ -222,7 +226,7 @@
         <dependency>
             <groupId>com.github.weisj</groupId>
             <artifactId>darklaf-core</artifactId>
-            <version>2.5.5</version>
+            <version>2.6.2-SNAPSHOT</version> <!-- TODO Change to release when ready -->
         </dependency>
         <dependency>
             <groupId>com.github.weisj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.31</version>
         </dependency>
         <dependency>
             <groupId>org.smali</groupId>

--- a/src/main/java/the/bytecode/club/bytecodeviewer/Constants.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/Constants.java
@@ -1,5 +1,6 @@
 package the.bytecode.club.bytecodeviewer;
 
+import org.objectweb.asm.Opcodes;
 import the.bytecode.club.bytecodeviewer.resources.ResourceType;
 
 import java.io.File;
@@ -38,6 +39,7 @@ public class Constants
 	public static String krakatauWorkingDirectory = getBCVDirectory() + fs + "krakatau_" + krakatauVersion;
 	public static String enjarifyWorkingDirectory = getBCVDirectory() + fs + "enjarify_" + enjarifyVersion;
 	public static final String[] SUPPORTED_FILE_EXTENSIONS = ResourceType.supportedBCVExtensionMap.keySet().toArray(new String[0]);
+	public static final int ASM_VERSION = Opcodes.ASM9;
 	
 	public static final PrintStream ERR = System.err;
 	public static final PrintStream OUT = System.out;

--- a/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingAnnotationAdapter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingAnnotationAdapter.java
@@ -31,8 +31,8 @@
 package the.bytecode.club.bytecodeviewer.obfuscators.mapping;
 
 import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Remapper;
+import the.bytecode.club.bytecodeviewer.Constants;
 
 /**
  * An {@link AnnotationVisitor} adapter for type remapping.
@@ -45,7 +45,7 @@ public class RemappingAnnotationAdapter extends AnnotationVisitor {
 
     public RemappingAnnotationAdapter(final AnnotationVisitor av,
                                       final org.objectweb.asm.commons.Remapper remapper) {
-        this(Opcodes.ASM5, av, remapper);
+        this(Constants.ASM_VERSION, av, remapper);
     }
 
     protected RemappingAnnotationAdapter(final int api,

--- a/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingClassAdapter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingClassAdapter.java
@@ -34,8 +34,8 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.TypePath;
+import the.bytecode.club.bytecodeviewer.Constants;
 
 /**
  * A {@link ClassVisitor} for type remapping.
@@ -49,7 +49,7 @@ public class RemappingClassAdapter extends ClassVisitor {
     protected String className;
 
     public RemappingClassAdapter(final ClassVisitor cv, final Remapper remapper) {
-        this(Opcodes.ASM5, cv, remapper);
+        this(Constants.ASM_VERSION, cv, remapper);
     }
 
     protected RemappingClassAdapter(final int api, final ClassVisitor cv,

--- a/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingFieldAdapter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingFieldAdapter.java
@@ -32,9 +32,9 @@ package the.bytecode.club.bytecodeviewer.obfuscators.mapping;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.TypePath;
 import org.objectweb.asm.commons.Remapper;
+import the.bytecode.club.bytecodeviewer.Constants;
 
 /**
  * A {@link FieldVisitor} adapter for type remapping.
@@ -46,7 +46,7 @@ public class RemappingFieldAdapter extends FieldVisitor {
     private final org.objectweb.asm.commons.Remapper remapper;
 
     public RemappingFieldAdapter(final FieldVisitor fv, final org.objectweb.asm.commons.Remapper remapper) {
-        this(Opcodes.ASM5, fv, remapper);
+        this(Constants.ASM_VERSION, fv, remapper);
     }
 
     protected RemappingFieldAdapter(final int api, final FieldVisitor fv,

--- a/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingMethodAdapter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingMethodAdapter.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.TypePath;
 import org.objectweb.asm.commons.LocalVariablesSorter;
 import org.objectweb.asm.commons.Remapper;
+import the.bytecode.club.bytecodeviewer.Constants;
 
 /**
  * A {@link LocalVariablesSorter} for type mapping.
@@ -50,7 +51,7 @@ public class RemappingMethodAdapter extends LocalVariablesSorter {
 
     public RemappingMethodAdapter(final int access, final String desc,
                                   final MethodVisitor mv, final org.objectweb.asm.commons.Remapper remapper) {
-        this(Opcodes.ASM5, access, desc, mv, remapper);
+        this(Constants.ASM_VERSION, access, desc, mv, remapper);
     }
 
     protected RemappingMethodAdapter(final int api, final int access,
@@ -125,7 +126,7 @@ public class RemappingMethodAdapter extends LocalVariablesSorter {
     @Override
     public void visitMethodInsn(final int opcode, final String owner,
                                 final String name, final String desc) {
-        if (api >= Opcodes.ASM5) {
+        if (api >= Constants.ASM_VERSION) {
             super.visitMethodInsn(opcode, owner, name, desc);
             return;
         }
@@ -136,7 +137,7 @@ public class RemappingMethodAdapter extends LocalVariablesSorter {
     @Override
     public void visitMethodInsn(final int opcode, final String owner,
                                 final String name, final String desc, final boolean itf) {
-        if (api < Opcodes.ASM5) {
+        if (api < Constants.ASM_VERSION) {
             super.visitMethodInsn(opcode, owner, name, desc, itf);
             return;
         }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingSignatureAdapter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/obfuscators/mapping/RemappingSignatureAdapter.java
@@ -30,9 +30,9 @@
 
 package the.bytecode.club.bytecodeviewer.obfuscators.mapping;
 
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.signature.SignatureVisitor;
+import the.bytecode.club.bytecodeviewer.Constants;
 
 /**
  * A {@link SignatureVisitor} adapter for type mapping.
@@ -49,7 +49,7 @@ public class RemappingSignatureAdapter extends SignatureVisitor {
 
     public RemappingSignatureAdapter(final SignatureVisitor v,
                                      final org.objectweb.asm.commons.Remapper remapper) {
-        this(Opcodes.ASM5, v, remapper);
+        this(Constants.ASM_VERSION, v, remapper);
     }
 
     protected RemappingSignatureAdapter(final int api,


### PR DESCRIPTION
Felt cute, wanted to Fix #312 
 - ASM now supports JDK 18+
 - DarkLaf Java 16 Fix (temporarily via snapshots. CHANGE BACK TO USING REGULAR RELEASE WHEN PROPER VERSION IS RELEASED)