### PR TITLE
Use fixed JDK versions and an OpenJDK distro that supports that

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17-ea' ] # LTS versions
+        java: [ 8, 8.0.192, 11, 11.0.3, 17, 17.0.0+35 ] # Latest and fixed versions
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'temurin'
+        distribution: 'zulu'
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Extract Maven project version


### PR DESCRIPTION
This pull request simplifies identification of build problems, i.e., when the fixed version is green, while the latest version is red, you'll know the problem is related to the latest version, Zulu has more historical OpenJDK major and minor versions and hence is suited for this approach, hence changing to Zulu as well.