### PR TITLE
resource leak due to Files.walk

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/JRTExtractor.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/JRTExtractor.java
@@ -18,9 +18,11 @@ import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -28,8 +30,9 @@ public class JRTExtractor {
     public static void extractRT(String path) throws Throwable {
         FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
 
-        try (ZipOutputStream zipStream = new ZipOutputStream(Files.newOutputStream(Paths.get(path)))) {
-            Files.walk(fs.getPath("/")).forEach(p -> {
+        try (ZipOutputStream zipStream = new ZipOutputStream(Files.newOutputStream(Paths.get(path)));
+			Stream<Path> stream =  Files.walk(fs.getPath("/"))) {
+            stream.forEach(p -> {
                 if (!Files.isRegularFile(p)) {
                     return;
                 }


### PR DESCRIPTION
Stream creates by File.walk should be closed, like jdk said:

<p> The returned stream encapsulates one or more {@link DirectoryStream}s.
If timely disposal of file system resources is required, the
{@code try}-with-resources construct should be used to ensure that the
stream's {@link Stream#close close} method is invoked after the stream
operations are completed. Operating on a closed stream will result in an
{@link java.lang.IllegalStateException}.
 