### PR TITLE
fix bugs occurring on Windows when trying to generate the method list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>the.bytecode.club</groupId>
     <artifactId>Bytecode-Viewer</artifactId>
-    <version>2.10.17</version>
+    <version>2.10.16</version>
 
     <properties>
         <!-- Project settings -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>the.bytecode.club</groupId>
     <artifactId>Bytecode-Viewer</artifactId>
-    <version>2.10.16</version>
+    <version>2.10.17</version>
 
     <properties>
         <!-- Project settings -->

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/MethodsRenderer.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/MethodsRenderer.java
@@ -1,9 +1,12 @@
 package the.bytecode.club.bytecodeviewer.gui.components;
 
 import java.awt.Component;
+import java.util.List;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
+
+import the.bytecode.club.bytecodeviewer.gui.resourceviewer.BytecodeViewPanel;
 import the.bytecode.club.bytecodeviewer.gui.util.BytecodeViewPanelUpdater;
 import the.bytecode.club.bytecodeviewer.util.MethodParser;
 
@@ -44,8 +47,16 @@ public class MethodsRenderer extends JLabel implements ListCellRenderer<Object>
 	public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
 	                                              boolean cellHasFocus)
 	{
-		MethodParser methods = bytecodeViewPanelUpdater.viewer.methods.get(bytecodeViewPanelUpdater.bytecodeViewPanel.decompiler.ordinal());
-		MethodParser.Method method = methods.getMethod((Integer) value);
+		int methodIndex = (Integer) value;
+		MethodParser methods;
+		List<MethodParser> methodParsers = bytecodeViewPanelUpdater.viewer.methods;
+		BytecodeViewPanel bytecodeViewPanel = bytecodeViewPanelUpdater.bytecodeViewPanel;
+		try {
+			methods = methodParsers.get(bytecodeViewPanel.decompiler.ordinal());
+		} catch (ArrayIndexOutOfBoundsException e) {
+			methods = methodParsers.get(bytecodeViewPanel.panelIndex);
+		}
+		MethodParser.Method method = methods.getMethod(methodIndex);
 		setText(method.toString());
 		return this;
 	}


### PR DESCRIPTION
On Windows (and maybe other OSes, I haven't thoroughly checked), an `ArrayIndexOutOfBoundsException` would be called upon having most decompilers active when method lists were attempted to be found for them. That would result in the method dropdown not existing which would mess up Swing/AWT and result in many more exceptions related to screen rendering and some NPEs.

This PR catches that initial `ArrayIndexOutOfBoundsException` which ends up setting some other fields. That ends up fixing NPEs which fixes other exceptions as well.