### PR TITLE
Update darklaf to version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.9</commons-text.version>
-        <darklaf.version>2.7.3</darklaf.version>
+        <darklaf.version>3.0.0</darklaf.version>
         <darklaf-extensions-rsta.version>0.3.4</darklaf-extensions-rsta.version>
         <decompiler-fernflower.version>5.2.1.Final</decompiler-fernflower.version>
         <dex2jar.version>v49</dex2jar.version>

--- a/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
@@ -93,9 +93,6 @@ import static the.bytecode.club.bytecodeviewer.Constants.tempDirectory;
  *      + Anything using blindlySearchForClassNode() should instead search through the resource container search function
  *      + BCV's classLoader should be destroyed each time a resource is added or removed
  *
- * TODO DarkLAF Specific Bugs:
- *      + JMenuBar can only be displayed on a JFrame, a work around is needed for this (Partially solved)
- *
  * TODO IN-PROGRESS:
  *      + Resource Exporter/Save/Decompile As Zip needs to be rewritten
  *      + Finish dragging code

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/VisibleComponent.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/VisibleComponent.java
@@ -1,10 +1,9 @@
 package the.bytecode.club.bytecodeviewer.gui.components;
 
-import com.github.weisj.darklaf.icons.ThemedSVGIcon;
+import com.github.weisj.darklaf.iconset.AllIcons;
 import javax.swing.BorderFactory;
 import javax.swing.JInternalFrame;
 import the.bytecode.club.bytecodeviewer.Configuration;
-import the.bytecode.club.bytecodeviewer.gui.resourceviewer.Workspace;
 import the.bytecode.club.bytecodeviewer.gui.theme.LAFTheme;
 import the.bytecode.club.bytecodeviewer.resources.IconResources;
 
@@ -55,7 +54,7 @@ public abstract class VisibleComponent extends JInternalFrame
     {
         try {
             if(Configuration.showDarkLAFComponentIcons)
-                setFrameIcon(new ThemedSVGIcon(Workspace.class.getResource("/com/github/weisj/darklaf/icons/frame/frame.svg").toURI(), 16, 16));
+                setFrameIcon(AllIcons.Window.Frame.get(16, 16));
             else
                 setFrameIcon(IconResources.jarIcon);
         } catch (Exception e) {

--- a/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginWriter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginWriter.java
@@ -133,14 +133,7 @@ public class PluginWriter extends JFrame
 			p.add(p2, BorderLayout.NORTH);
 			p.add(component, BorderLayout.CENTER);
 
-			JMenuBar menuBar = getJMenuBar();
-			// As the Darklaf windows decorations steal the menu bar from the frame
-			// it sets the preferred size to (0,0). Because we want to steal the menu bar ourselves.
-			// we have to revert this change.
-			// Remove when https://github.com/weisJ/darklaf/issues/258 is fixed and available in a
-			// release.
-			menuBar.setPreferredSize(null);
-			p2.add(menuBar, BorderLayout.CENTER);
+			p2.add(getJMenuBar(), BorderLayout.CENTER);
 
 			ComponentViewer.addComponentAsTab(pluginName, p);
 		}


### PR DESCRIPTION
This resolves an outstanding issue allowing us to remove the
temporary fix for it. Also, the "frame.svg" icon is now loaded
using the official API and no longer relies on the exact location
of the resource.