### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,21 +23,20 @@
         <cloning.version>1.9.12</cloning.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-compiler.version>3.1.6</commons-compiler.version>
+        <commons-compiler.version>3.1.7</commons-compiler.version>
         <commons-compress.version>1.21</commons-compress.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.9</commons-text.version>
         <darklaf.version>3.0.0</darklaf.version>
-        <darklaf-extensions-rsta.version>0.3.4</darklaf-extensions-rsta.version>
+        <darklaf-extensions-rsta.version>0.4.1</darklaf-extensions-rsta.version>
         <decompiler-fernflower.version>5.2.1.Final</decompiler-fernflower.version>
         <dex2jar.version>v49</dex2jar.version>
         <fernflower.version>4281855</fernflower.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>31.1-jre</guava.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
-        <jadx.version>1.3.4</jadx.version>
-        <janino.version>3.1.6</janino.version>
+        <jadx.version>1.3.5</jadx.version>
         <jd-gui.version>1.6.6bcv</jd-gui.version>
         <jgraphx.version>3.4.1.3</jgraphx.version>
         <js.version>21.2.0</js.version>
@@ -210,7 +209,7 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>${janino.version}</version>
+            <version>${commons-compiler.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jd</groupId>


### PR DESCRIPTION
ANTLR appearently uses Java 11 for some of its classes.
Let's not upgrade it yet, but rather test intensively if something breaks with the new version at some point :)