### PR TITLE
Update Maven Shade Plugin to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
https://blogs.apache.org/maven/entry/apache-maven-shade-plugin-version6

> Release Notes - Maven Shade Plugin - Version 3.3.0
> 
> 
> ** Bug
>     * [MSHADE-252] - shadeSourcesContent is broken when combined with partial relocation
>     * [MSHADE-378] - Shade plugin changes the compression level of nested jar entries
>     * [MSHADE-396] - Improve SourceContent Shading
> 
> 
> ** New Feature
>     * [MSHADE-36] - Add option to include dependency reduced POM instead of original one
> 
> 
> ** Improvement
>     * [MSHADE-321] - Always respect 'createDependencyReducedPom' flag
>     * [MSHADE-371] - Update Shade Apache[Notice/LICENSE]ResourceTransformer to use also [NOTICE/LICENSE].md
>     * [MSHADE-373] - Source transformation on source jar can break OSGi resolution due to duplicated bundle name
>     * [MSHADE-382] - Add an option to skip execution
>     * [MSHADE-391] - Do not modify class files, if nothing was relocated
>     * [MSHADE-405] - ShowOverlapping Uses http instead of https
> 
> 
> 
> ** Task
>     * [MSHADE-389] - Get rid of old baggage
>     * [MSHADE-390] - Implement Sisu index transformer
>     * [MSHADE-401] - Improve ServiceResourceTransformer
>     * [MSHADE-412] - SimpleRelocator can fail in NPE, in particular with manifest transformer