### PR TITLE
Add ASMifier support

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/CommandLineInput.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/CommandLineInput.java
@@ -100,6 +100,7 @@ public class CommandLineInput {
                 System.out.println("Krakatau-Bytecode");
                 System.out.println("JD-GUI");
                 System.out.println("Smali");
+                System.out.println("ASMifier");
                 return STOP;
             } else if (cmd.hasOption("clean")) {
                 new File(Constants.getBCVDirectory()).delete();
@@ -163,7 +164,8 @@ public class CommandLineInput {
                                 !decompiler.equalsIgnoreCase("krakatau") &&
                                 !decompiler.equalsIgnoreCase("krakatau-bytecode") &&
                                 !decompiler.equalsIgnoreCase("jd-gui") &&
-                                !decompiler.equalsIgnoreCase("smali")
+                                !decompiler.equalsIgnoreCase("smali") &&
+                                !decompiler.equalsIgnoreCase("asmifier")
                 ) {
                     System.out.println("Error, no decompiler called '" + decompiler + "' found. Type -list"
                             + " for the list");
@@ -350,6 +352,26 @@ public class CommandLineInput {
                         ClassNode cn = BytecodeViewer.blindlySearchForClassNode(target);
                         final ClassWriter cw = accept(cn);
                         String contents = Decompiler.JADX_DECOMPILER.getDecompiler().decompileClassNode(cn, cw.toByteArray());
+                        DiskWriter.replaceFile(output.getAbsolutePath(), contents, false);
+                    } catch (Exception e) {
+                        BytecodeViewer.handleException(e);
+                    }
+                }
+            }
+            else if (decompiler.equalsIgnoreCase("asmifier")) {
+                System.out.println("Generating ASM code for " + input.getAbsolutePath() + " with ASMifier");
+                BytecodeViewer.openFiles(new File[]{input}, false);
+
+                Thread.sleep(5 * 1000);
+
+                if (target.equalsIgnoreCase("all")) {
+                    System.out.println("Coming soon.");
+                    //Decompiler.smali.decompileToZip(output.getAbsolutePath());
+                } else {
+                    try {
+                        ClassNode cn = BytecodeViewer.blindlySearchForClassNode(target);
+                        final ClassWriter cw = accept(cn);
+                        String contents = Decompiler.ASMIFIER_DECOMPILER.getDecompiler().decompileClassNode(cn, cw.toByteArray());
                         DiskWriter.replaceFile(output.getAbsolutePath(), contents, false);
                     } catch (Exception e) {
                         BytecodeViewer.handleException(e);

--- a/src/main/java/the/bytecode/club/bytecodeviewer/CommandLineInput.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/CommandLineInput.java
@@ -165,7 +165,7 @@ public class CommandLineInput {
                                 !decompiler.equalsIgnoreCase("jd-gui") &&
                                 !decompiler.equalsIgnoreCase("smali")
                 ) {
-                    System.out.println("Error, no decompiler called '" + decompiler + "' found. Type -decompiler-list"
+                    System.out.println("Error, no decompiler called '" + decompiler + "' found. Type -list"
                             + " for the list");
                 }
 

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/Decompiler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/Decompiler.java
@@ -1,16 +1,6 @@
 package the.bytecode.club.bytecodeviewer.decompilers;
 
-import the.bytecode.club.bytecodeviewer.decompilers.impl.ASMTextifierDisassembler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.BytecodeDisassembler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.CFRDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.FernFlowerDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.JADXDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.JDGUIDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.JavapDisassembler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.KrakatauDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.KrakatauDisassembler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.ProcyonDecompiler;
-import the.bytecode.club.bytecodeviewer.decompilers.impl.SmaliDisassembler;
+import the.bytecode.club.bytecodeviewer.decompilers.impl.*;
 
 /***************************************************************************
  * Bytecode Viewer (BCV) - Java & Android Reverse Engineering Suite        *
@@ -51,6 +41,7 @@ public enum Decompiler
     JD_DECOMPILER("JD-GUI Decompiler", "jdgui", new JDGUIDecompiler()),
     JADX_DECOMPILER("JADX Decompiler", "jadx", new JADXDecompiler()),
     ASM_TEXTIFY_DISASSEMBLER("ASM Disassembler", "asm", new ASMTextifierDisassembler()),
+    ASMIFIER_DECOMPILER("ASMifier Generator", "asmifier", new ASMifierGenerator()),
     JAVAP_DISASSEMBLER("Javap Disassembler", "javap", new JavapDisassembler()),
     ;
     

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/ASMifierGenerator.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/ASMifierGenerator.java
@@ -1,0 +1,47 @@
+package the.bytecode.club.bytecodeviewer.decompilers.impl;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceClassVisitor;
+import the.bytecode.club.bytecodeviewer.decompilers.InternalDecompiler;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/***************************************************************************
+ * Bytecode Viewer (BCV) - Java & Android Reverse Engineering Suite        *
+ * Copyright (C) 2014 Kalen 'Konloch' Kinloch - http://bytecodeviewer.com  *
+ *                                                                         *
+ * This program is free software: you can redistribute it and/or modify    *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation, either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+/**
+ * Objectweb ASMifier output
+ *
+ * @author Nick Botticelli
+ */
+public class ASMifierGenerator extends InternalDecompiler
+{
+    @Override
+    public String decompileClassNode(ClassNode cn, byte[] b) {
+        StringWriter writer = new StringWriter();
+        cn.accept(new TraceClassVisitor(null, new ASMifier(), new PrintWriter(writer)));
+        return writer.toString();
+    }
+
+    @Override
+    public void decompileToZip(String sourceJar, String zipName) {
+    }
+}

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/DecompilerViewComponent.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/DecompilerViewComponent.java
@@ -11,10 +11,7 @@ import the.bytecode.club.bytecodeviewer.translation.TranslatedComponents;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedJCheckBoxMenuItem;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedJRadioButtonMenuItem;
 
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.BYTECODE;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.BYTECODE_NON_EDITABLE;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.JAVA;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.JAVA_AND_BYTECODE;
+import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.*;
 
 /***************************************************************************
  * Bytecode Viewer (BCV) - Java & Android Reverse Engineering Suite        *
@@ -63,12 +60,12 @@ public class DecompilerViewComponent
 	
 	private void createMenu()
 	{
-		if(type == JAVA || type == JAVA_AND_BYTECODE)
+		if(type == JAVA || type == JAVA_NON_EDITABLE || type == JAVA_AND_BYTECODE)
 			menu.add(java);
 		if(type == BYTECODE || type == JAVA_AND_BYTECODE || type == BYTECODE_NON_EDITABLE)
 			menu.add(bytecode);
 		
-		if(type != BYTECODE_NON_EDITABLE)
+		if(type != JAVA_NON_EDITABLE && type != BYTECODE_NON_EDITABLE)
 		{
 			menu.add(new JSeparator());
 			menu.add(editable);
@@ -79,7 +76,7 @@ public class DecompilerViewComponent
 	
 	public void addToGroup(ButtonGroup group)
 	{
-		if(type == JAVA || type == JAVA_AND_BYTECODE)
+		if(type == JAVA || type == JAVA_NON_EDITABLE || type == JAVA_AND_BYTECODE)
 			group.add(java);
 		if(type == BYTECODE || type == JAVA_AND_BYTECODE || type == BYTECODE_NON_EDITABLE)
 			group.add(bytecode);
@@ -118,6 +115,7 @@ public class DecompilerViewComponent
 	public enum DecompilerComponentType
 	{
 		JAVA,
+		JAVA_NON_EDITABLE,
 		BYTECODE,
 		BYTECODE_NON_EDITABLE,
 		JAVA_AND_BYTECODE

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DecompilerSelectionPane.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DecompilerSelectionPane.java
@@ -164,9 +164,7 @@ public class DecompilerSelectionPane
 	
 	public Decompiler getSelectedDecompiler()
 	{
-		javax.swing.ButtonModel selection = group.getSelection();
-		String actionCommand = selection.getActionCommand();
-		return Decompiler.valueOf(actionCommand);
+		return Decompiler.valueOf(group.getSelection().getActionCommand());
 	}
 	
 	public void setSelectedDecompiler(Decompiler decompiler)

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DecompilerSelectionPane.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DecompilerSelectionPane.java
@@ -18,10 +18,7 @@ import the.bytecode.club.bytecodeviewer.translation.TranslatedComponents;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedJMenu;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedJRadioButtonMenuItem;
 
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.BYTECODE;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.BYTECODE_NON_EDITABLE;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.JAVA;
-import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.JAVA_AND_BYTECODE;
+import static the.bytecode.club.bytecodeviewer.gui.components.DecompilerViewComponent.DecompilerComponentType.*;
 
 /***************************************************************************
  * Bytecode Viewer (BCV) - Java & Android Reverse Engineering Suite        *
@@ -61,12 +58,13 @@ public class DecompilerSelectionPane
 	private final DecompilerViewComponent smali = new DecompilerViewComponent("Smali", BYTECODE, Decompiler.SMALI_DISASSEMBLER);
 	private final DecompilerViewComponent bytecode = new DecompilerViewComponent("Bytecode", BYTECODE_NON_EDITABLE, Decompiler.BYTECODE_DISASSEMBLER);
 	private final DecompilerViewComponent asmTextify = new DecompilerViewComponent("ASM Textify", BYTECODE_NON_EDITABLE, Decompiler.ASM_TEXTIFY_DISASSEMBLER);
+	private final DecompilerViewComponent asmifier = new DecompilerViewComponent("ASMifier", JAVA_NON_EDITABLE, Decompiler.ASMIFIER_DECOMPILER);
 	private final DecompilerViewComponent javap = new DecompilerViewComponent("Javap", BYTECODE_NON_EDITABLE, Decompiler.JAVAP_DISASSEMBLER);
 	
 	//TODO when adding new decompilers insert the DecompilerViewComponent object into here
 	// also in the group, then finally the build menu
 	public List<DecompilerViewComponent> components = new ArrayList<>(Arrays.asList(
-			procyon, CFR, JADX, JD, fern, krakatau, smali, bytecode, asmTextify, javap));
+			procyon, CFR, JADX, JD, fern, krakatau, smali, bytecode, asmTextify, asmifier, javap));
 	
 	public DecompilerSelectionPane(int paneID)
 	{
@@ -159,13 +157,16 @@ public class DecompilerSelectionPane
 		menu.add(bytecode.getMenu());
 		menu.add(javap.getMenu());
 		menu.add(asmTextify.getMenu());
+		menu.add(asmifier.getMenu());
 		menu.add(new JSeparator());
 		menu.add(hexcode);
 	}
 	
 	public Decompiler getSelectedDecompiler()
 	{
-		return Decompiler.valueOf(group.getSelection().getActionCommand());
+		javax.swing.ButtonModel selection = group.getSelection();
+		String actionCommand = selection.getActionCommand();
+		return Decompiler.valueOf(actionCommand);
 	}
 	
 	public void setSelectedDecompiler(Decompiler decompiler)

--- a/src/main/java/the/bytecode/club/bytecodeviewer/translation/TranslatedComponents.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/translation/TranslatedComponents.java
@@ -94,7 +94,8 @@ public enum TranslatedComponents
 	BYTECODE,
 	HEXCODE,
 	ASM_TEXTIFY,
-	
+	ASMIFIER,
+
 	SETTINGS,
 	COMPILE_ON_SAVE,
 	COMPILE_ON_REFRESH,

--- a/src/main/java/the/bytecode/club/bytecodeviewer/translation/TranslatedStrings.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/translation/TranslatedStrings.java
@@ -54,6 +54,7 @@ public enum TranslatedStrings
 	HEXCODE,
 	BYTECODE,
 	ASM_TEXTIFY,
+	ASMIFIER,
 	ERROR,
 	DISASSEMBLER,
 	RESULTS,

--- a/src/main/resources/translations/english.json
+++ b/src/main/resources/translations/english.json
@@ -96,6 +96,7 @@
   "HEXCODE": "Hexcode",
   "BYTECODE": "Bytecode",
   "ASM_TEXTIFY": "ASM Textify",
+  "ASMIFIER": "ASMifier",
 
   "BYTECODE_DECOMPILER": "Bytecode Decompiler",
   "DEBUG_HELPERS": "Debug Helpers",


### PR DESCRIPTION
This adds ASMifier support to address #426. The code is pretty much the same as the ASM Textifier disassembler, just substituting `new Textifier()` with `new ASMifier()`.

This includes support for CLI, which I have tested successfully, and also fixed a typo that tells users to use `-decompiler-list` which is not valid. I noticed that some decompilers/disassemblers, such as ASM Textify, do not have CLI support, which I wouldn't mind adding (maybe in a separate PR).

Additionally, this PR adds an additional entry in `DecompilerComponentType`: `JAVA_NON_EDITABLE`. ASMifier output is logically not editable (similar to ASM Textifier) but outputs Java code and not Bytecode.

I have only added a translation under English, so I do not know if this would be a concern.

[Here](https://gist.github.com/nick-botticelli/78bbbb90c12d55110f9191fd484dad83) is an example using `the.bytecode.club.bytecodeviewer.Settings` class as an input.