### PR TITLE
Fix FernFlower "Rename ambiguous classes and class elements".

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/FernFlowerDecompiler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/FernFlowerDecompiler.java
@@ -118,7 +118,12 @@ public class FernFlowerDecompiler extends InternalDecompiler
 
         tempClass.delete();
 
-        final File outputJava = new File(start + ".java");
+        String javaDir = start;
+        if (BytecodeViewer.viewer.ren.isSelected()) {
+            javaDir = tempDirectory + "class_0";
+        }
+
+        final File outputJava = new File(javaDir + ".java");
         if (outputJava.exists()) {
             String s;
             try {


### PR DESCRIPTION
This fixes issue #385. FernFlower creates a file "class_0.java" when renaming is checked rather than using the usual naming used by BCV. This allows BCV to find the correct file that is output by FernFlower, even if that option is not selected.