### PR TITLE
Update dependencies as of this commit date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <commons-cli.version>1.5.0</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-compiler.version>3.1.9</commons-compiler.version>
-        <commons-compress.version>1.21</commons-compress.version>
+        <commons-compress.version>1.22</commons-compress.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.10.0</commons-text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <!-- Dependency versions -->
         <annotations.version>23.0.0</annotations.version>
         <antlr4.version>4.9.3</antlr4.version>
-        <apktool.version>2.6.1</apktool.version>
+        <apktool.version>2.7.0</apktool.version>
         <asm.version>9.4</asm.version>
         <bined.version>0.2.0</bined.version>
         <byteanalysis.version>1.0bcv</byteanalysis.version>
@@ -23,20 +23,20 @@
         <cloning.version>1.9.12</cloning.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-compiler.version>3.1.8</commons-compiler.version>
+        <commons-compiler.version>3.1.9</commons-compiler.version>
         <commons-compress.version>1.21</commons-compress.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.10.0</commons-text.version>
         <darklaf.version>3.0.2</darklaf.version>
         <darklaf-extensions-rsta.version>0.4.1</darklaf-extensions-rsta.version>
-        <decompiler-fernflower.version>6.0.0.Final</decompiler-fernflower.version>
+        <decompiler-fernflower.version>6.1.0.Final</decompiler-fernflower.version>
         <dex2jar.version>v56</dex2jar.version>
         <fernflower.version>e0d44f4</fernflower.version>
-        <gson.version>2.9.1</gson.version>
+        <gson.version>2.10</gson.version>
         <guava.version>31.1-jre</guava.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
-        <jadx.version>1.4.4</jadx.version>
+        <jadx.version>1.4.5</jadx.version>
         <jd-gui.version>1.6.6bcv</jd-gui.version>
         <jgraphx.version>3.4.1.3</jgraphx.version>
         <js.version>21.2.0</js.version>
@@ -45,7 +45,7 @@
         <procyon.version>0.6.0</procyon.version>
         <rsyntaxtextarea.version>3.3.0</rsyntaxtextarea.version>
         <semantic-version.version>2.1.1</semantic-version.version>
-        <slf4j.version>2.0.3</slf4j.version>
+        <slf4j.version>2.0.5</slf4j.version>
         <smali.version>2.5.2</smali.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <treelayout.version>1.0.3</treelayout.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <darklaf.version>3.0.2</darklaf.version>
         <darklaf-extensions-rsta.version>0.4.1</darklaf-extensions-rsta.version>
         <decompiler-fernflower.version>6.1.0.Final</decompiler-fernflower.version>
-        <dex2jar.version>v56</dex2jar.version>
+        <dex2jar.version>v57</dex2jar.version>
         <fernflower.version>e0d44f4</fernflower.version>
         <gson.version>2.10</gson.version>
         <guava.version>31.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dependency versions -->
-        <annotations.version>23.0.0</annotations.version>
+        <annotations.version>23.1.0</annotations.version>
         <antlr4.version>4.9.3</antlr4.version>
         <apktool.version>2.7.0</apktool.version>
         <asm.version>9.4</asm.version>


### PR DESCRIPTION
Updated dependencies due to IntelliJ complaining about various (transitive) dependency vulnerabilities; did not update ANTLR dependency. Initial testing with JADX and Fernflower decompilers as well as APKs works fine.

There are still three more complaints about (transitive) dependency vulnerabilities:
* `org.jboss.windup.decompiler:decompiler-fernflower` – Transitive dependency Apache Commons Collection: Cx78f40514-81ff (Uncontrolled recursion)
* `org.smali:smali` – Transitive dependency jcommander: Cx8fd408ac-dd80 (Inclusion of functionality from untrusted control sphere)
* `org.yaml:snakeyaml` – CVE-2022-41854 (6.5; stack-based buffer overflow)

These should probably be updated promptly when a new version is released.