### PR TITLE
DND Support and Scrolling

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/MainViewerGUI.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/MainViewerGUI.java
@@ -116,7 +116,7 @@ public class MainViewerGUI extends JFrame
     public final SearchBoxPane searchBoxPane = new SearchBoxPane();
     public JSplitPane splitPane1;
     public JSplitPane splitPane2;
-    
+
     //the root menu bar
     public final JMenuBar rootMenu = new JMenuBar();
     
@@ -351,9 +351,12 @@ public class MainViewerGUI extends JFrame
         searchBoxPane.setPreferredSize(new Dimension(200, 50));
         searchBoxPane.setMinimumSize(new Dimension(200, 50));
         searchBoxPane.setMaximumSize(new Dimension(200, 2147483647));
-        
+
+        workPane.setPreferredSize(new Dimension(1500, 1000));
+
         splitPane1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT, resourcePane, searchBoxPane);
         splitPane2 = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, splitPane1, workPane);
+
         getContentPane().add(splitPane2);
         splitPane2.setResizeWeight(0.05);
         splitPane1.setResizeWeight(0.5);
@@ -361,6 +364,7 @@ public class MainViewerGUI extends JFrame
         uiComponents.add(resourcePane);
         uiComponents.add(searchBoxPane);
         uiComponents.add(workPane);
+//        uiComponents.add(hierarchy);
 
         viewPane1.setDefault();
         viewPane2.setDefault();

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/CloseButtonComponent.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/CloseButtonComponent.java
@@ -1,23 +1,15 @@
 package the.bytecode.club.bytecodeviewer.gui.resourceviewer;
 
-import com.android.tools.r8.internal.Cl;
 import com.github.weisj.darklaf.components.CloseButton;
-import com.github.weisj.darklaf.listener.MouseClickListener;
 import the.bytecode.club.bytecodeviewer.gui.components.listeners.MouseClickedListener;
 import the.bytecode.club.bytecodeviewer.translation.TranslatedStrings;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 
 public class CloseButtonComponent extends JPanel {
 
 	private final JTabbedPane pane;
-
-	String title = "";
 
 	public CloseButtonComponent(final JTabbedPane pane) {
 		super(new FlowLayout(FlowLayout.LEFT, 0, 0));

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DraggableTabbedPane.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/DraggableTabbedPane.java
@@ -1,5 +1,6 @@
 package the.bytecode.club.bytecodeviewer.gui.resourceviewer;
 
+import com.github.weisj.darklaf.ui.tabbedpane.DarkTabbedPaneUI;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 
 import javax.swing.*;
@@ -16,106 +17,75 @@ public class DraggableTabbedPane extends JTabbedPane {
 	private static final int LINEWIDTH = 3;
 	private static final String NAME = "TabTransferData";
 	private final DataFlavor FLAVOR = new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType, NAME);
-	private static GhostGlassPane s_glassPane = new GhostGlassPane();
+	private static final GhostGlassPane s_glassPane = new GhostGlassPane();
 
 	private boolean m_isDrawRect = false;
 	private final Rectangle2D m_lineRect = new Rectangle2D.Double();
 
 	private final Color m_lineColor = new Color(0, 100, 255);
-	private TabAcceptor m_acceptor = null;
+	private TabAcceptor m_acceptor;
 
 	public DraggableTabbedPane() {
 		super(SwingConstants.TOP, SCROLL_TAB_LAYOUT);
+		this.putClientProperty(DarkTabbedPaneUI.KEY_DND, true);
 
-		final DragSourceListener dsl = new DragSourceListener() {
-			public void dragEnter(DragSourceDragEvent e) {
-				e.getDragSourceContext().setCursor(DragSource.DefaultMoveDrop);
-			}
-
-			public void dragExit(DragSourceEvent e) {
-				e.getDragSourceContext().setCursor(DragSource.DefaultMoveNoDrop);
-				m_lineRect.setRect(0, 0, 0, 0);
-				m_isDrawRect = false;
-				s_glassPane.setPoint(new Point(-1000, -1000));
-				s_glassPane.repaint();
-			}
-
-			public void dragOver(DragSourceDragEvent e) {
-				//e.getLocation()
-				//This method returns a Point indicating the cursor location in screen coordinates at the moment
-
-				TabTransferData data = getTabTransferData(e);
-				if (data == null) {
-					e.getDragSourceContext().setCursor(
-							DragSource.DefaultMoveNoDrop);
-					return;
-				} // if
-
-                /*
-                Point tabPt = e.getLocation();
-                SwingUtilities.convertPointFromScreen(tabPt, DnDTabbedPane.this);
-                if (DnDTabbedPane.this.contains(tabPt)) {
-                    int targetIdx = getTargetTabIndex(tabPt);
-                    int sourceIndex = data.getTabIndex();
-                    if (getTabAreaBound().contains(tabPt)
-                            && (targetIdx >= 0)
-                            && (targetIdx != sourceIndex)
-                            && (targetIdx != sourceIndex + 1)) {
-                        e.getDragSourceContext().setCursor(
-                                DragSource.DefaultMoveDrop);
-
-                        return;
-                    } // if
-
-                    e.getDragSourceContext().setCursor(
-                            DragSource.DefaultMoveNoDrop);
-                    return;
-                } // if
-                */
-
-				e.getDragSourceContext().setCursor(
-						DragSource.DefaultMoveDrop);
-			}
-
-			public void dragDropEnd(DragSourceDropEvent e) {
-				m_isDrawRect = false;
-				m_lineRect.setRect(0, 0, 0, 0);
-				// m_dragTabIndex = -1;
-
-				if (hasGhost()) {
-					s_glassPane.setVisible(false);
-					s_glassPane.setImage(null);
+		/*if (!Configuration.showDarkLAFComponentIcons) {
+			final DragSourceListener dsl = new DragSourceListener() {
+				public void dragEnter(DragSourceDragEvent e) {
+					e.getDragSourceContext().setCursor(DragSource.DefaultMoveDrop);
 				}
-			}
 
-			public void dropActionChanged(DragSourceDragEvent e) {
-			}
-		};
+				public void dragExit(DragSourceEvent e) {
+					e.getDragSourceContext().setCursor(DragSource.DefaultMoveNoDrop);
+					m_lineRect.setRect(0, 0, 0, 0);
+					m_isDrawRect = false;
+					s_glassPane.setPoint(new Point(-1000, -1000));
+					s_glassPane.repaint();
+				}
 
-		final DragGestureListener dgl = e -> {
-			// System.out.println("dragGestureRecognized");
+				public void dragOver(DragSourceDragEvent e) {
+					TabTransferData data = getTabTransferData(e);
+					if (data == null) {
+						e.getDragSourceContext().setCursor(
+								DragSource.DefaultMoveNoDrop);
+						return;
+					}
 
-			Point tabPt = e.getDragOrigin();
-			int dragTabIndex = indexAtLocation(tabPt.x, tabPt.y);
-			if (dragTabIndex < 0) {
-				return;
-			} // if
+					e.getDragSourceContext().setCursor(DragSource.DefaultMoveDrop);
+				}
 
-			initGlassPane(e.getComponent(), e.getDragOrigin(), dragTabIndex);
-			try {
-				e.startDrag(DragSource.DefaultMoveDrop,
-						new TabTransferable(DraggableTabbedPane.this, dragTabIndex), dsl);
-			} catch (InvalidDnDOperationException idoe) {
-				idoe.printStackTrace();
-			}
-		};
+				public void dragDropEnd(DragSourceDropEvent e) {
+					m_isDrawRect = false;
+					m_lineRect.setRect(0, 0, 0, 0);
+					if (hasGhost()) {
+						s_glassPane.setVisible(false);
+						s_glassPane.setImage(null);
+					}
+				}
 
-		//dropTarget =
-		new DropTarget(this, DnDConstants.ACTION_COPY_OR_MOVE,
-				new CDropTargetListener(), true);
-		new DragSource().createDefaultDragGestureRecognizer(this,
-				DnDConstants.ACTION_COPY_OR_MOVE, dgl);
-		m_acceptor = (a_component, a_index) -> true;
+				public void dropActionChanged(DragSourceDragEvent e) {
+				}
+			};
+
+			final DragGestureListener dgl = e -> {
+				Point tabPt = e.getDragOrigin();
+				int dragTabIndex = indexAtLocation(tabPt.x, tabPt.y);
+				if (dragTabIndex < 0) {
+					return;
+				}
+
+				initGlassPane(e.getComponent(), e.getDragOrigin(), dragTabIndex);
+				try {
+					e.startDrag(DragSource.DefaultMoveDrop, new TabTransferable(DraggableTabbedPane.this, dragTabIndex), dsl);
+				} catch (InvalidDnDOperationException idoe) {
+					idoe.printStackTrace();
+				}
+			};
+
+			new DropTarget(this, DnDConstants.ACTION_COPY_OR_MOVE, new CDropTargetListener(), true);
+			new DragSource().createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY_OR_MOVE, dgl);
+			m_acceptor = (a_component, a_index) -> true;
+		}*/
 	}
 
 	public TabAcceptor getAcceptor() {
@@ -131,7 +101,7 @@ public class DraggableTabbedPane extends JTabbedPane {
 		if (!t.isDataFlavorSupported(FLAVOR)) return null;
 
 		try {
-			return (TabTransferData) t.getTransferData(FLAVOR);
+			return (TabTransferData) a_event.getTransferable().getTransferData(FLAVOR);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -144,7 +114,7 @@ public class DraggableTabbedPane extends JTabbedPane {
 		if (!t.isDataFlavorSupported(FLAVOR)) return null;
 
 		try {
-			return (TabTransferData) t.getTransferData(FLAVOR);
+			return (TabTransferData) a_event.getTransferable().getTransferData(FLAVOR);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -157,7 +127,7 @@ public class DraggableTabbedPane extends JTabbedPane {
 		if (!t.isDataFlavorSupported(FLAVOR)) return null;
 
 		try {
-			return (TabTransferData) t.getTransferData(FLAVOR);
+			return (TabTransferData) a_event.getDragSourceContext().getTransferable().getTransferData(FLAVOR);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -175,7 +145,6 @@ public class DraggableTabbedPane extends JTabbedPane {
 
 		public Object getTransferData(DataFlavor flavor) {
 			return m_data;
-			// return DnDTabbedPane.this;
 		}
 
 		public DataFlavor[] getTransferDataFlavors() {
@@ -246,27 +215,23 @@ public class DraggableTabbedPane extends JTabbedPane {
 				retval.y -= s_glassPane.getGhostHeight() / 2;
 			}
 			break;
-		} // switch
+		}
 
-		retval = SwingUtilities.convertPoint(DraggableTabbedPane.this,
-				retval, s_glassPane);
+		retval = SwingUtilities.convertPoint(DraggableTabbedPane.this, retval, s_glassPane);
 		return retval;
 	}
 
 	class CDropTargetListener implements DropTargetListener {
 
 		public void dragEnter(DropTargetDragEvent e) {
-			// System.out.println("DropTarget.dragEnter: " + DnDTabbedPane.this);
-
 			if (isDragAcceptable(e)) {
 				e.acceptDrag(e.getDropAction());
 			} else {
 				e.rejectDrag();
-			} // if
+			}
 		}
 
 		public void dragExit(DropTargetEvent e) {
-			// System.out.println("DropTarget.dragExit: " + DnDTabbedPane.this);
 			m_isDrawRect = false;
 		}
 
@@ -282,7 +247,7 @@ public class DraggableTabbedPane extends JTabbedPane {
 				initTargetLeftRightLine(getTargetTabIndex(e.getLocation()), data);
 			} else {
 				initTargetTopBottomLine(getTargetTabIndex(e.getLocation()), data);
-			} // if-else
+			}
 
 			repaint();
 			if (hasGhost()) {
@@ -292,14 +257,12 @@ public class DraggableTabbedPane extends JTabbedPane {
 		}
 
 		public void drop(DropTargetDropEvent a_event) {
-			// System.out.println("DropTarget.drop: " + DnDTabbedPane.this);
-
 			if (isDropAcceptable(a_event)) {
 				convertTab(getTabTransferData(a_event), getTargetTabIndex(a_event.getLocation()));
 				a_event.dropComplete(true);
 			} else {
 				a_event.dropComplete(false);
-			} // if-else
+			}
 
 			m_isDrawRect = false;
 			repaint();
@@ -311,12 +274,12 @@ public class DraggableTabbedPane extends JTabbedPane {
 			Transferable t = e.getTransferable();
 			if (t == null) {
 				return false;
-			} // if
+			}
 
 			DataFlavor[] flavor = e.getCurrentDataFlavors();
 			if (!t.isDataFlavorSupported(flavor[0])) {
 				return false;
-			} // if
+			}
 
 			TabTransferData data = getTabTransferData(e);
 			if (data == null) return false;
@@ -324,13 +287,13 @@ public class DraggableTabbedPane extends JTabbedPane {
 			if (DraggableTabbedPane.this == data.getTabbedPane()
 					&& data.getTabIndex() >= 0) {
 				return true;
-			} // if
+			}
 
 			if (DraggableTabbedPane.this != data.getTabbedPane()) {
 				if (m_acceptor != null) {
 					return m_acceptor.isDropAcceptable(data.getTabbedPane(), data.getTabIndex());
-				} // if
-			} // if
+				}
+			}
 
 			return false;
 		}
@@ -339,12 +302,12 @@ public class DraggableTabbedPane extends JTabbedPane {
 			Transferable t = e.getTransferable();
 			if (t == null) {
 				return false;
-			} // if
+			}
 
 			DataFlavor[] flavor = e.getCurrentDataFlavors();
 			if (!t.isDataFlavorSupported(flavor[0])) {
 				return false;
-			} // if
+			}
 
 			TabTransferData data = getTabTransferData(e);
 			if (data == null) return false;
@@ -352,13 +315,13 @@ public class DraggableTabbedPane extends JTabbedPane {
 			if (DraggableTabbedPane.this == data.getTabbedPane()
 					&& data.getTabIndex() >= 0) {
 				return true;
-			} // if
+			}
 
 			if (DraggableTabbedPane.this != data.getTabbedPane()) {
 				if (m_acceptor != null) {
 					return m_acceptor.isDropAcceptable(data.getTabbedPane(), data.getTabIndex());
-				} // if
-			} // if
+				}
+			}
 
 			return false;
 		}
@@ -387,20 +350,20 @@ public class DraggableTabbedPane extends JTabbedPane {
 		// if the pane is empty, the target index is always zero.
 		if (getTabCount() == 0) {
 			return 0;
-		} // if
+		}
 
 		for (int i = 0; i < getTabCount(); i++) {
 			Rectangle r = getBoundsAt(i);
 			if (isTopOrBottom) {
-				r.setRect(r.x - r.width / 2, r.y, r.width, r.height);
+				r.setRect(r.x - r.width / 2D, r.y, r.width, r.height);
 			} else {
-				r.setRect(r.x, r.y - r.height / 2, r.width, r.height);
-			} // if-else
+				r.setRect(r.x, r.y - r.height / 2D, r.width, r.height);
+			}
 
 			if (r.contains(a_point)) {
 				return i;
-			} // if
-		} // for
+			}
+		}
 
 		Rectangle r = getBoundsAt(getTabCount() - 1);
 		if (isTopOrBottom) {
@@ -409,18 +372,19 @@ public class DraggableTabbedPane extends JTabbedPane {
 		} else {
 			int y = r.y + r.height / 2;
 			r.setRect(r.x, y, r.width, getHeight() - y);
-		} // if-else
+		}
 
 		return r.contains(a_point) ? getTabCount() : -1;
 	}
 
 	private void convertTab(TabTransferData a_data, int a_targetIndex) {
 		if (a_data == null) return;
+
 		DraggableTabbedPane source = a_data.getTabbedPane();
 		int sourceIndex = a_data.getTabIndex();
 		if (sourceIndex < 0) {
 			return;
-		} // if
+		}
 
 		Component cmp = source.getComponentAt(sourceIndex);
 		String str = source.getTitleAt(sourceIndex);
@@ -432,34 +396,28 @@ public class DraggableTabbedPane extends JTabbedPane {
 			} else {
 				if (a_targetIndex < 0) {
 					a_targetIndex = 0;
-				} // if
+				}
 
 				insertTab(str, null, cmp, null, a_targetIndex);
-
-			} // if
+			}
 
 			setSelectedComponent(cmp);
-			// System.out.println("press="+sourceIndex+" next="+a_targetIndex);
 			return;
-		} // if
+		}
 
 		if (a_targetIndex < 0 || sourceIndex == a_targetIndex) {
-			//System.out.println("press="+prev+" next="+next);
 			return;
-		} // if
+		}
 
 		if (a_targetIndex == getTabCount()) {
-			//System.out.println("last: press="+prev+" next="+next);
 			source.remove(sourceIndex);
 			addTab(str, cmp);
 			setSelectedIndex(getTabCount() - 1);
 		} else if (sourceIndex > a_targetIndex) {
-			//System.out.println("   >: press="+prev+" next="+next);
 			source.remove(sourceIndex);
 			insertTab(str, null, cmp, null, a_targetIndex);
 			setSelectedIndex(a_targetIndex);
 		} else {
-			//System.out.println("   <: press="+prev+" next="+next);
 			source.remove(sourceIndex);
 			insertTab(str, null, cmp, null, a_targetIndex - 1);
 			setSelectedIndex(a_targetIndex - 1);
@@ -471,31 +429,27 @@ public class DraggableTabbedPane extends JTabbedPane {
 			m_lineRect.setRect(0, 0, 0, 0);
 			m_isDrawRect = false;
 			return;
-		} // if
-        if (a_data == null) return;
+		}
 
-		if ((a_data.getTabbedPane() == this)
-				&& (a_data.getTabIndex() == next
-				|| next - a_data.getTabIndex() == 1)) {
+		if (a_data == null) return;
+
+		if ((a_data.getTabbedPane() == this) && (a_data.getTabIndex() == next || next - a_data.getTabIndex() == 1)) {
 			m_lineRect.setRect(0, 0, 0, 0);
 			m_isDrawRect = false;
 		} else if (getTabCount() == 0) {
 			m_lineRect.setRect(0, 0, 0, 0);
 			m_isDrawRect = false;
-			return;
 		} else if (next == 0) {
 			Rectangle rect = getBoundsAt(0);
-			m_lineRect.setRect(-LINEWIDTH / 2, rect.y, LINEWIDTH, rect.height);
+			m_lineRect.setRect(-LINEWIDTH / 2D, rect.y, LINEWIDTH, rect.height);
 			m_isDrawRect = true;
 		} else if (next == getTabCount()) {
 			Rectangle rect = getBoundsAt(getTabCount() - 1);
-			m_lineRect.setRect(rect.x + rect.width - LINEWIDTH / 2, rect.y,
-					LINEWIDTH, rect.height);
+			m_lineRect.setRect(rect.x + rect.width - LINEWIDTH / 2D, rect.y, LINEWIDTH, rect.height);
 			m_isDrawRect = true;
 		} else {
 			Rectangle rect = getBoundsAt(next - 1);
-			m_lineRect.setRect(rect.x + rect.width - LINEWIDTH / 2, rect.y,
-					LINEWIDTH, rect.height);
+			m_lineRect.setRect(rect.x + rect.width - LINEWIDTH / 2D, rect.y, LINEWIDTH, rect.height);
 			m_isDrawRect = true;
 		}
 	}
@@ -505,12 +459,11 @@ public class DraggableTabbedPane extends JTabbedPane {
 			m_lineRect.setRect(0, 0, 0, 0);
 			m_isDrawRect = false;
 			return;
-		} // if
+		}
+
 		if (a_data == null) return;
 
-		if ((a_data.getTabbedPane() == this)
-				&& (a_data.getTabIndex() == next
-				|| next - a_data.getTabIndex() == 1)) {
+		if ((a_data.getTabbedPane() == this) && (a_data.getTabIndex() == next || next - a_data.getTabIndex() == 1)) {
 			m_lineRect.setRect(0, 0, 0, 0);
 			m_isDrawRect = false;
 		} else if (getTabCount() == 0) {
@@ -519,33 +472,29 @@ public class DraggableTabbedPane extends JTabbedPane {
 			return;
 		} else if (next == getTabCount()) {
 			Rectangle rect = getBoundsAt(getTabCount() - 1);
-			m_lineRect.setRect(rect.x, rect.y + rect.height - LINEWIDTH / 2,
-					rect.width, LINEWIDTH);
+			m_lineRect.setRect(rect.x, rect.y + rect.height - LINEWIDTH / 2D, rect.width, LINEWIDTH);
 			m_isDrawRect = true;
 		} else if (next == 0) {
 			Rectangle rect = getBoundsAt(0);
-			m_lineRect.setRect(rect.x, -LINEWIDTH / 2, rect.width, LINEWIDTH);
+			m_lineRect.setRect(rect.x, -LINEWIDTH / 2D, rect.width, LINEWIDTH);
 			m_isDrawRect = true;
 		} else {
 			Rectangle rect = getBoundsAt(next - 1);
-			m_lineRect.setRect(rect.x, rect.y + rect.height - LINEWIDTH / 2,
-					rect.width, LINEWIDTH);
+			m_lineRect.setRect(rect.x, rect.y + rect.height - LINEWIDTH / 2D, rect.width, LINEWIDTH);
 			m_isDrawRect = true;
 		}
 	}
 
 	private void initGlassPane(Component c, Point tabPt, int a_tabIndex) {
-		//Point p = (Point) pt.clone();
 		getRootPane().setGlassPane(s_glassPane);
 		if (hasGhost()) {
 			Rectangle rect = getBoundsAt(a_tabIndex);
-			BufferedImage image = new BufferedImage(c.getWidth(),
-					c.getHeight(), BufferedImage.TYPE_INT_ARGB);
+			BufferedImage image = new BufferedImage(c.getWidth(), c.getHeight(), BufferedImage.TYPE_INT_ARGB);
 			Graphics g = image.getGraphics();
 			c.paint(g);
 			image = image.getSubimage(rect.x, rect.y, rect.width, rect.height);
 			s_glassPane.setImage(image);
-		} // if
+		}
 
 		s_glassPane.setPoint(buildGhostLocation(tabPt));
 		s_glassPane.setVisible(true);
@@ -563,7 +512,7 @@ public class DraggableTabbedPane extends JTabbedPane {
 			Graphics2D g2 = (Graphics2D) g;
 			g2.setPaint(m_lineColor);
 			g2.fill(m_lineRect);
-		} // if
+		}
 	}
 
 	public interface TabAcceptor {
@@ -577,7 +526,7 @@ class GhostGlassPane extends JPanel {
 	public static final long serialVersionUID = 1L;
 	private final AlphaComposite m_composite;
 
-	private Point m_location = new Point(0, 0);
+	private final Point m_location = new Point(0, 0);
 
 	private BufferedImage m_draggingGhost = null;
 
@@ -598,7 +547,7 @@ class GhostGlassPane extends JPanel {
 	public int getGhostWidth() {
 		if (m_draggingGhost == null) {
 			return 0;
-		} // if
+		}
 
 		return m_draggingGhost.getWidth(this);
 	}
@@ -606,7 +555,7 @@ class GhostGlassPane extends JPanel {
 	public int getGhostHeight() {
 		if (m_draggingGhost == null) {
 			return 0;
-		} // if
+		}
 
 		return m_draggingGhost.getHeight(this);
 	}
@@ -614,7 +563,7 @@ class GhostGlassPane extends JPanel {
 	public void paintComponent(Graphics g) {
 		if (m_draggingGhost == null) {
 			return;
-		} // if
+		}
 
 		Graphics2D g2 = (Graphics2D) g;
 		g2.setComposite(m_composite);

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/TabbedPane.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/TabbedPane.java
@@ -1,22 +1,13 @@
 package the.bytecode.club.bytecodeviewer.gui.resourceviewer;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.FlowLayout;
-import java.awt.Rectangle;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import javax.swing.*;
-
-import com.github.weisj.darklaf.components.CloseButton;
-import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.gui.components.ButtonHoverAnimation;
 import the.bytecode.club.bytecodeviewer.gui.components.MaxWidthJLabel;
-import the.bytecode.club.bytecodeviewer.gui.components.listeners.MouseClickedListener;
 import the.bytecode.club.bytecodeviewer.gui.resourceviewer.viewer.ResourceViewer;
 import the.bytecode.club.bytecodeviewer.gui.util.DelayTabbedPaneThread;
-import the.bytecode.club.bytecodeviewer.translation.TranslatedStrings;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseListener;
 
 /***************************************************************************
  * Bytecode Viewer (BCV) - Java & Android Reverse Engineering Suite        *
@@ -56,7 +47,7 @@ public class TabbedPane extends JPanel {
 	public final static MouseListener buttonHoverAnimation = new ButtonHoverAnimation();
 	public static final Color BLANK_COLOR = new Color(0, 0, 0, 0);
 
-	public TabbedPane(int tabIndex, String tabWorkingName, String fileContainerName, String name, final DraggableTabbedPane existingTabs, ResourceViewer resource) {
+	public TabbedPane(int tabIndex, String tabWorkingName, String fileContainerName, String name, final JTabbedPane existingTabs, ResourceViewer resource) {
 		// unset default FlowLayout' gaps
 		super(new FlowLayout(FlowLayout.LEFT, 0, 0));
 
@@ -80,33 +71,5 @@ public class TabbedPane extends JPanel {
 		setBorder(BorderFactory.createEmptyBorder(2, 0, 0, 0));
 	}
 
-    public void onMousePressed(MouseEvent e)
-    {
-        BytecodeViewer.viewer.workPane.tabs.dispatchEvent(e);
-    
-        if(e.getButton() == 1)
-        {
-            startedDragging = System.currentTimeMillis();
-            //dragging = true;
-            if (probablyABadIdea != null)
-                probablyABadIdea.stopped = true;
-            
-            probablyABadIdea = new DelayTabbedPaneThread(TabbedPane.this);
-            probablyABadIdea.start();
-            repaint();
-            Rectangle bounds = new Rectangle(e.getX(), e.getY(), e.getX() + this.getX(), e.getY());
-            for(int i = 0; i < BytecodeViewer.viewer.workPane.tabs.getTabCount(); i++)
-            {
-                Component c = BytecodeViewer.viewer.workPane.tabs.getTabComponentAt(i);
-                if(c != null && bounds.intersects(c.getBounds()))
-                    BytecodeViewer.viewer.workPane.tabs.setSelectedIndex(i);
-            }
-        }
-    }
-
 	private static final long serialVersionUID = -4774885688297538774L;
-
-	/*public int getTabIndex() {
-		return tabs.indexOfTabComponent(this);
-	}*/
 }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/Workspace.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/Workspace.java
@@ -1,16 +1,5 @@
 package the.bytecode.club.bytecodeviewer.gui.resourceviewer;
 
-import java.awt.*;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.HashSet;
-import java.util.Set;
-import javax.swing.JButton;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-
-import com.github.weisj.darklaf.components.CloseButton;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.decompilers.Decompiler;
 import the.bytecode.club.bytecodeviewer.gui.resourceviewer.viewer.ClassViewer;
@@ -21,6 +10,13 @@ import the.bytecode.club.bytecodeviewer.translation.TranslatedComponents;
 import the.bytecode.club.bytecodeviewer.translation.TranslatedStrings;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedJButton;
 import the.bytecode.club.bytecodeviewer.translation.components.TranslatedVisibleComponent;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.HashSet;
+import java.util.Set;
 
 import static the.bytecode.club.bytecodeviewer.Constants.BLOCK_TAB_MENU;
 
@@ -52,7 +48,7 @@ import static the.bytecode.club.bytecodeviewer.Constants.BLOCK_TAB_MENU;
 
 public class Workspace extends TranslatedVisibleComponent {
 
-	public final DraggableTabbedPane tabs;
+	public JTabbedPane tabs;
 	public final JPanel buttonPanel;
 	public final JButton refreshClass;
 	public final Set<String> openedTabs = new HashSet<>();
@@ -193,7 +189,7 @@ public class Workspace extends TranslatedVisibleComponent {
 			//search through each tab
 			for (int i = 0; i < tabs.getTabCount(); i++) {
 				//find the matching resource and open it
-                ResourceViewer tab = (ResourceViewer) tabs.getComponentAt(i);
+				ResourceViewer tab = (ResourceViewer) tabs.getComponentAt(i);
 				if (tab.resource.workingName.equals(workingName)) {
 					tabs.setSelectedIndex(i);
 					break;


### PR DESCRIPTION
As commit says, I removed the portion of DND support I committed a few weeks/months ago, to enable the already supported DND from weisJ. I also, fixed an issue with having a class open and then switching theme and not being able to scroll. Don't know if it was just me or other people had this issue.

DND support - Windows theme doesn't work with this change, however the other themes do now. Possibly get rid of the basic windows theme all together?