### PR TITLE
fix clicking on empty space in row not opening file

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourcelist/ResourceListPane.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourcelist/ResourceListPane.java
@@ -484,8 +484,8 @@ public class ResourceListPane extends TranslatedVisibleComponent implements File
         this.tree.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                if(e.getButton() == MouseEvent.BUTTON1) //right-click
-                    openPath(tree.getPathForLocation(e.getX(), e.getY()));
+                if (e.getButton() == MouseEvent.BUTTON1) // left-click
+                    openPath(tree.getClosestPathForLocation(e.getX(), e.getY()));
             }
         });
     


### PR DESCRIPTION
You would be unable to open files in the sidebar if you clicked on the empty space to the left / right of the file names in various situations
It's janky behaviour which has annoyed me for a while now