### PR TITLE
fix right-clicking close tab button closes popup menu

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/CloseButtonComponent.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/resourceviewer/CloseButtonComponent.java
@@ -6,6 +6,7 @@ import the.bytecode.club.bytecodeviewer.translation.TranslatedStrings;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.MouseEvent;
 
 public class CloseButtonComponent extends JPanel {
 
@@ -45,6 +46,9 @@ public class CloseButtonComponent extends JPanel {
 
 		button.addMouseListener(new MouseClickedListener(e ->
 		{
+			if (e.getButton() != MouseEvent.BUTTON1) // left-click
+				return;
+
 			if (pane.indexOfTabComponent(CloseButtonComponent.this) != -1)
 				pane.remove(pane.indexOfTabComponent(CloseButtonComponent.this));
 		}));


### PR DESCRIPTION
There is existing behaviour which lets you right click the "close tab" button, to show options to: "close all but this", "close tab"
But you could never use it because any mouse click (left or right) would simply close the tab.
Makes the app very tedious to use.

tl;dr you can now right click the "close tab" button to see and interact with its context menu