### PR TITLE
A few things

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,9 +17,9 @@ jobs:
         java: [ '8', '11', '17', '21' ] # LTS versions
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
@@ -30,7 +30,7 @@ jobs:
       run: echo "bcv_version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV
       id: project
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ matrix.java == '8' }}
       with:
         name: Bytecode-Viewer-${{ env.bcv_version }}-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,8 @@
                                 <exclude>META-INF/*NOTICE*</exclude>
                                 <exclude>META-INF/MANIFEST.MF</exclude>
                                 <exclude>LICENSE</exclude>
+                                <exclude>license.txt</exclude>
+                                <exclude>NOTICE</exclude>
                             </excludes>
                         </filter>
                         <!-- Ignore all ASM-related files from d2j-external but MCTLE fix -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <darklaf.version>3.0.2</darklaf.version>
         <darklaf-extensions-rsta.version>0.4.1</darklaf-extensions-rsta.version>
         <decompiler-fernflower.version>6.3.7.Final</decompiler-fernflower.version>
-        <dex2jar.version>2.4.16</dex2jar.version>
+        <dex2jar.version>2.4.17</dex2jar.version>
         <fernflower.version>e0d44f4</fernflower.version>
         <gson.version>2.10.1</gson.version>
         <guava.version>33.1.0-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,25 +15,25 @@
         <!-- Dependency versions -->
         <annotations.version>24.1.0</annotations.version>
         <apktool.version>2.9.3</apktool.version>
-        <asm.version>9.6</asm.version>
+        <asm.version>9.7</asm.version>
         <bined.version>0.2.1</bined.version>
         <byteanalysis.version>1.0bcv</byteanalysis.version>
         <cfr.version>0.152</cfr.version>
         <cloning.version>1.9.12</cloning.version>
         <commons-cli.version>1.6.0</commons-cli.version>
-        <commons-codec.version>1.16.0</commons-codec.version>
-        <commons-compiler.version>3.1.11</commons-compiler.version>
-        <commons-compress.version>1.25.0</commons-compress.version>
-        <commons-io.version>2.15.1</commons-io.version>
+        <commons-codec.version>1.16.1</commons-codec.version>
+        <commons-compiler.version>3.1.12</commons-compiler.version>
+        <commons-compress.version>1.26.1</commons-compress.version>
+        <commons-io.version>2.16.1</commons-io.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-text.version>1.11.0</commons-text.version>
         <darklaf.version>3.0.2</darklaf.version>
         <darklaf-extensions-rsta.version>0.4.1</darklaf-extensions-rsta.version>
-        <decompiler-fernflower.version>6.3.6.Final</decompiler-fernflower.version>
-        <dex2jar.version>2.4.11</dex2jar.version>
+        <decompiler-fernflower.version>6.3.7.Final</decompiler-fernflower.version>
+        <dex2jar.version>2.4.16</dex2jar.version>
         <fernflower.version>e0d44f4</fernflower.version>
         <gson.version>2.10.1</gson.version>
-        <guava.version>33.0.0-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <httprequest.version>2.2.0</httprequest.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
         <jadx.version>1.4.7</jadx.version>
@@ -43,13 +43,13 @@
         <objenesis.version>3.3</objenesis.version>
         <binary-data.version>0.2.1</binary-data.version>
         <procyon.version>0.6.0</procyon.version>
-        <rsyntaxtextarea.version>3.3.4</rsyntaxtextarea.version>
+        <rsyntaxtextarea.version>3.4.0</rsyntaxtextarea.version>
         <semantic-version.version>2.1.1</semantic-version.version>
-        <slf4j.version>2.0.11</slf4j.version>
-        <smali.version>3.0.3</smali.version>
+        <slf4j.version>2.0.12</slf4j.version>
+        <smali.version>3.0.5</smali.version>
         <safeyaml.version>1.34.1</safeyaml.version>
         <treelayout.version>1.0.3</treelayout.version>
-        <webp-imageio.version>0.7.0</webp-imageio.version>
+        <webp-imageio.version>a8f700b</webp-imageio.version>
         <xpp3.version>1.1.4c</xpp3.version>
     </properties>
 
@@ -358,7 +358,7 @@
             <version>${darklaf-extensions-rsta.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.usefulness</groupId>
+            <groupId>com.github.ThexXTURBOXx</groupId>
             <artifactId>webp-imageio</artifactId>
             <version>${webp-imageio.version}</version>
         </dependency>

--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/Dex2Jar.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/Dex2Jar.java
@@ -1,11 +1,13 @@
 package the.bytecode.club.bytecodeviewer.util;
 
+import com.googlecode.d2j.DexException;
+import com.googlecode.d2j.Method;
 import com.googlecode.d2j.dex.Dex2jar;
 import com.googlecode.d2j.dex.DexExceptionHandler;
-import com.googlecode.d2j.Method;
 import com.googlecode.d2j.node.DexMethodNode;
-import org.objectweb.asm.MethodVisitor;
+import com.googlecode.dex2jar.tools.Jar2Dex;
 import java.io.File;
+import org.objectweb.asm.MethodVisitor;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 
 /***************************************************************************
@@ -43,17 +45,19 @@ public class Dex2Jar {
     public static synchronized void dex2Jar(File input, File output) {
         try {
             Dex2jar d2Jar = Dex2jar.from(input)
-                                   .withExceptionHandler(new DexExceptionHandler() {
-                                       public void handleFileException(Exception e) {
-                                           e.printStackTrace();
-                                       }
-                                       
-                                       public void handleMethodTranslateException(Method method, DexMethodNode methodNode, MethodVisitor mv, Exception e) {
-                                           e.printStackTrace();
-                                       }
-                                   });
+                    .computeFrames(true)
+                    .withExceptionHandler(new DexExceptionHandler() {
+                        public void handleFileException(Exception e) {
+                            e.printStackTrace();
+                        }
+
+                        public void handleMethodTranslateException(Method method, DexMethodNode methodNode,
+                                                                   MethodVisitor mv, Exception e) {
+                            e.printStackTrace();
+                        }
+                    });
             d2Jar.to(output.toPath());
-        } catch (com.googlecode.d2j.DexException e) {
+        } catch (DexException e) {
             e.printStackTrace();
         } catch (Exception e) {
             BytecodeViewer.handleException(e);
@@ -72,7 +76,8 @@ public class Dex2Jar {
 
     public static synchronized void saveAsDex(File input, File output, boolean delete) {
         try {
-            com.googlecode.dex2jar.tools.Jar2Dex.main(input.getAbsolutePath(),
+            Jar2Dex.main(input.getAbsolutePath(),
+                    "-f",
                     "-o", output.getAbsolutePath(),
                     "-s", BytecodeViewer.viewer.getMinSdkVersion() + "");
             if (delete)
@@ -81,4 +86,5 @@ public class Dex2Jar {
             BytecodeViewer.handleException(e);
         }
     }
+
 }

--- a/src/main/resources/translations/english.json
+++ b/src/main/resources/translations/english.json
@@ -286,5 +286,6 @@
   "MATCH_CASE": "Match Case",
   "EXACT_PATH": "Exact Path",
   "MIN_SDK_VERSION": "Minimum SDK version",
-  "PRINT_LINE_NUMBERS": "Print Line Numbers"
+  "PRINT_LINE_NUMBERS": "Print Line Numbers",
+  "AUTO_OPEN": "Open automatically"
 }

--- a/src/main/resources/translations/german.json
+++ b/src/main/resources/translations/german.json
@@ -286,5 +286,6 @@
   "MATCH_CASE": "Groß-/Kleinschreibung beachten",
   "EXACT_PATH": "Genauer Pfad",
   "MIN_SDK_VERSION": "Minimale SDK-Version",
-  "PRINT_LINE_NUMBERS": "Zeilennummern einschließen"
+  "PRINT_LINE_NUMBERS": "Zeilennummern einschließen",
+  "AUTO_OPEN": "Automatisch öffnen"
 }


### PR DESCRIPTION
 - Add AUTO_OPEN to I18n (I did that a while ago - cannot remember why)
 - Use computeFrames in dex2jar (This yields more accurate output and circumvents a few bugs)
 - Update actions to Node.JS 20 (the old Node.JS 16 versions have been deprecated quite some time ago already)
 - Update dependencies in general (including webp-imageio to own fork supporting Java 8)

Hence, this PR:
Fixes #487 