### PR TITLE
Font size spinner also updates opened tabs automatically now.

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/BytecodeViewer.java
@@ -675,7 +675,7 @@ public class BytecodeViewer
     }
     
     /**
-     * Refreshes the title on all of the opened tabs
+     * Refreshes all the opened tabs
      */
     public static void refreshAllTabs()
     {
@@ -684,7 +684,7 @@ public class BytecodeViewer
             updateBusyStatus(true);
             for (int i = 0; i < BytecodeViewer.viewer.workPane.tabs.getTabCount(); i++)
             {
-                ResourceViewer viewer = ((TabbedPane) BytecodeViewer.viewer.workPane.tabs.getTabComponentAt(i)).resource;
+                ResourceViewer viewer = (ResourceViewer) BytecodeViewer.viewer.workPane.tabs.getComponentAt(i);
                 viewer.refresh(null);
             }
             updateBusyStatus(false);

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/MainViewerGUI.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/MainViewerGUI.java
@@ -2,10 +2,8 @@ package the.bytecode.club.bytecodeviewer.gui;
 
 import java.awt.*;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -352,7 +350,6 @@ public class MainViewerGUI extends JFrame
         uiComponents.add(resourcePane);
         uiComponents.add(searchBoxPane);
         uiComponents.add(workPane);
-//        uiComponents.add(hierarchy);
 
         viewPane1.setDefault();
         viewPane2.setDefault();
@@ -465,6 +462,7 @@ public class MainViewerGUI extends JFrame
 
 			BytecodeViewer.updateAllFonts(font);
 			BytecodeViewer.updateUI();
+            BytecodeViewer.refreshAllTabs();
 		});
         fontSize.add(fontSpinner);
         


### PR DESCRIPTION
Font size spinner now updates the opened tabs without needing to click the "Refresh" button. I didn't realize there was already a method that would accomplish this. Also, since finding this method, I found that it would produce an exception, which is now fixed.