### PR TITLE
Replace System.getProperty(...) separator calls

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/Constants.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/Constants.java
@@ -2,6 +2,7 @@ package the.bytecode.club.bytecodeviewer;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.FileSystems;
 
 import org.objectweb.asm.Opcodes;
 import the.bytecode.club.bytecodeviewer.resources.ResourceType;
@@ -66,8 +67,8 @@ public class Constants
 	//if true the version checker will prompt and ask how you would like to proceed
 	public static final boolean FORCE_VERSION_CHECKER_PROMPT = false;
 	
-	public static final String fs = System.getProperty("file.separator");
-	public static final String nl = System.getProperty("line.separator");
+	public static final String fs = FileSystems.getDefault().getSeparator();
+	public static final String nl = System.lineSeparator();
 	
 	public static final File BCVDir = resolveBCVRoot();
 	public static final File RT_JAR = new File(System.getProperty("java.home") + fs + "lib" + fs + "rt.jar");

--- a/src/main/java/the/bytecode/club/bytecodeviewer/compilers/impl/JavaCompiler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/compilers/impl/JavaCompiler.java
@@ -87,7 +87,7 @@ public class JavaCompiler extends InternalCompiler
                         Configuration.javac,
                         "-d", fileStart2,
                         "-classpath",
-                        cp.getAbsolutePath() + System.getProperty("path.separator") + Configuration.library,
+                        cp.getAbsolutePath() + File.pathSeparator + Configuration.library,
                         java.getAbsolutePath()
                 );
             }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/resources/ExternalResources.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/resources/ExternalResources.java
@@ -379,7 +379,7 @@ public class ExternalResources
 
 			while ((line = reader.readLine()) != null) {
 				builder.append(line);
-				builder.append(System.getProperty("line.separator"));
+				builder.append(System.lineSeparator());
 			}
 
 			return builder.toString();

--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/NewlineOutputStream.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/NewlineOutputStream.java
@@ -38,7 +38,7 @@ public class NewlineOutputStream extends FilterOutputStream {
     public NewlineOutputStream(OutputStream os) {
         super(os);
         if (newline == null) {
-            String s = System.getProperty("line.separator");
+            String s = System.lineSeparator();
             if (s == null || s.length() <= 0)
                 s = "\n";
             newline = s.getBytes(StandardCharsets.ISO_8859_1);    // really us-ascii


### PR DESCRIPTION
Replaces `System.getProperty(...)` separator calls with with `System.lineSeparator` and `File.pathSeparator`. This was recommended by IntelliJ; initial tests show that this functions as intended.

Environment:
* Azul arm64 JDK 1.8
* arm64 macOS 15 Beta