### PR TITLE
[Go-to] Removed the check for packages that start with "java", "javax", etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <objenesis.version>3.4</objenesis.version>
         <binary-data.version>0.2.1</binary-data.version>
         <procyon.version>0.6.0</procyon.version>
-        <rsyntaxtextarea.version>3.5.1</rsyntaxtextarea.version>
+        <rsyntaxtextarea.version>3.5.2</rsyntaxtextarea.version> <!-- Upcoming 4.0 release will require Java 11+ -->
         <semantic-version.version>2.1.1</semantic-version.version>
         <slf4j.version>2.0.16</slf4j.version>
         <smali.version>3.0.8</smali.version>

--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/actions/GoToAction.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/actions/GoToAction.java
@@ -201,9 +201,6 @@ public class GoToAction extends AbstractAction
 
                 String packagePath = classReferenceLocation.packagePath;
 
-                if (packagePath.startsWith("java") || packagePath.startsWith("javax") || packagePath.startsWith("com.sun"))
-                    return null;
-
                 if (!packagePath.isEmpty())
                     className = packagePath + "/" + className.substring(className.lastIndexOf('/') + 1);
             }
@@ -239,9 +236,6 @@ public class GoToAction extends AbstractAction
 
             String packagePath = classReferenceLocation.packagePath;
 
-            if (packagePath.startsWith("java") || packagePath.startsWith("javax") || packagePath.startsWith("com.sun"))
-                return null;
-
             String resourceName = classMethodLocation.owner;
             if (!packagePath.isEmpty())
                 resourceName = packagePath + "/" + classMethodLocation.owner;
@@ -258,9 +252,6 @@ public class GoToAction extends AbstractAction
         {
             ClassReferenceLocation classReferenceLocation = container.getClassReferenceLocationsFor(lexeme).get(0);
             String packagePath = classReferenceLocation.packagePath;
-
-            if (packagePath.startsWith("java") || packagePath.startsWith("javax") || packagePath.startsWith("com.sun"))
-                return null;
 
             String resourceName = lexeme;
             if (!packagePath.isEmpty())


### PR DESCRIPTION
As the title states, I removed the check for packages with similar package names as the JRE.

During the simple testing with it removed, everything works as usual, and no errors are thrown when trying to go to a class that is not included in the opened resource.

I also updated the RSyntaxTextArea version that removes all of the logging that was accidentally left in.