### PR TITLE
fix ArrayIndexOutOfBoundsException in FileHeaderUtils

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/FileHeaderUtils.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/FileHeaderUtils.java
@@ -30,6 +30,8 @@ public class FileHeaderUtils
 
     public static boolean doesFileHeaderMatch(byte[] bytes, int fileHeader)
     {
+        if (bytes.length < 4) return false;
+
         int bytesHeader = ((bytes[0] & 0xFF) << 24)
             | ((bytes[1] & 0xFF) << 16)
             | ((bytes[2] & 0xFF) << 8)


### PR DESCRIPTION
Hi,

This patch fixes an ArrayIndexOutOfBoundsException when the input array is smaller than the inspected range.