### PR TITLE
skip compression & decompression when using Dex2Jar

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/compilers/impl/SmaliAssembler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/compilers/impl/SmaliAssembler.java
@@ -20,12 +20,10 @@ package the.bytecode.club.bytecodeviewer.compilers.impl;
 
 import com.konloch.disklib.DiskWriter;
 import org.apache.commons.io.FileUtils;
-import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.compilers.AbstractCompiler;
-import the.bytecode.club.bytecodeviewer.util.Dex2Jar;
-import the.bytecode.club.bytecodeviewer.util.Enjarify;
 import the.bytecode.club.bytecodeviewer.util.MiscUtils;
 import the.bytecode.club.bytecodeviewer.util.ZipUtils;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Apk2Jar;
 
 import java.io.File;
 import java.util.Objects;
@@ -77,22 +75,14 @@ public class SmaliAssembler extends AbstractCompiler
             //BytecodeViewer.handleException(e);
         }
 
-
-        if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionDex.getModel()))
-            Dex2Jar.dex2Jar(tempDex, tempJar);
-        else if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionEnjarify.getModel()))
-            Enjarify.apk2Jar(tempDex, tempJar);
+        File current = Apk2Jar.obtainImpl().apk2Folder(tempDex);
 
         System.out.println("Temporary dex: " + tempDex.getAbsolutePath());
 
         try
         {
-            System.out.println("Unzipping to " + tempJarFolder.getAbsolutePath());
-            ZipUtils.unzipFilesToPath(tempJar.getAbsolutePath(), tempJarFolder.getAbsolutePath());
-
             File outputClass = null;
             boolean found = false;
-            File current = tempJarFolder;
             try
             {
                 while (!found)

--- a/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/SmaliDisassembler.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/decompilers/impl/SmaliDisassembler.java
@@ -26,7 +26,7 @@ import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.api.ExceptionUI;
 import the.bytecode.club.bytecodeviewer.decompilers.AbstractDecompiler;
 import the.bytecode.club.bytecodeviewer.translation.TranslatedStrings;
-import the.bytecode.club.bytecodeviewer.util.Dex2Jar;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Dex2Jar;
 import the.bytecode.club.bytecodeviewer.util.MiscUtils;
 
 import java.io.*;

--- a/src/main/java/the/bytecode/club/bytecodeviewer/resources/ResourceContainerImporter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/resources/ResourceContainerImporter.java
@@ -26,6 +26,7 @@ import the.bytecode.club.bytecodeviewer.api.ASMUtil;
 import the.bytecode.club.bytecodeviewer.util.FileHeaderUtils;
 import the.bytecode.club.bytecodeviewer.util.MiscUtils;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,14 +66,49 @@ public class ResourceContainerImporter
         }
     }
 
+    private void clearContainerResources()
+    {
+        container.resourceClasses.clear();
+        container.resourceClassBytes.clear();
+        container.resourceFiles.clear();
+    }
+
+    public ResourceContainerImporter importAsFolder() throws IOException
+    {
+        clearContainerResources();
+
+        File folder = container.file;
+        String folderPath = folder.getAbsolutePath() + File.separator;
+        importFolder(folderPath, container.file, true);
+
+        return this;
+    }
+
+    private void importFolder(String rootPath, File folder, boolean classesOnly) throws IOException
+    {
+
+        for (File file : folder.listFiles())
+        {
+            if (file.isDirectory())
+            {
+                importFolder(rootPath, file, classesOnly);
+            } else
+            {
+                try (FileInputStream fis = new FileInputStream(file))
+                {
+                    String name = file.getAbsolutePath().substring(rootPath.length());
+                    addUnknownFile(name, fis, classesOnly);
+                }
+            }
+        }
+    }
+
     /**
      * Start importing the container file as a zip archive
      */
     public ResourceContainerImporter importAsZip() throws IOException
     {
-        container.resourceClasses.clear();
-        container.resourceClassBytes.clear();
-        container.resourceFiles.clear();
+        clearContainerResources();
 
         try
         {

--- a/src/main/java/the/bytecode/club/bytecodeviewer/resources/exporting/impl/DexExport.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/resources/exporting/impl/DexExport.java
@@ -22,7 +22,7 @@ import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.Configuration;
 import the.bytecode.club.bytecodeviewer.gui.components.FileChooser;
 import the.bytecode.club.bytecodeviewer.resources.exporting.Exporter;
-import the.bytecode.club.bytecodeviewer.util.Dex2Jar;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Dex2Jar;
 import the.bytecode.club.bytecodeviewer.util.DialogUtils;
 import the.bytecode.club.bytecodeviewer.util.JarUtils;
 import the.bytecode.club.bytecodeviewer.util.MiscUtils;
@@ -78,7 +78,7 @@ public class DexExport implements Exporter
                         {
                             BytecodeViewer.updateBusyStatus(true);
                             final String input = TEMP_DIRECTORY + FS + MiscUtils.getRandomizedName() + ".jar";
-                            
+
                             JarUtils.saveAsJar(BytecodeViewer.getLoadedClasses(), input);
 
                             Thread saveAsDex = new Thread(() ->

--- a/src/main/java/the/bytecode/club/bytecodeviewer/resources/importing/impl/APKResourceImporter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/resources/importing/impl/APKResourceImporter.java
@@ -21,9 +21,9 @@ package the.bytecode.club.bytecodeviewer.resources.importing.impl;
 import org.apache.commons.io.FileUtils;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.resources.ResourceContainer;
-import the.bytecode.club.bytecodeviewer.resources.ResourceContainerImporter;
 import the.bytecode.club.bytecodeviewer.resources.importing.Importer;
 import the.bytecode.club.bytecodeviewer.util.*;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Apk2Jar;
 
 import java.io.File;
 
@@ -56,16 +56,8 @@ public class APKResourceImporter implements Importer
         container.resourceFiles.putAll(JarUtils.loadResources(tempCopy)); // copy and rename
         // to prevent unicode filenames
 
-        String name = MiscUtils.getRandomizedName() + ".jar";
-        File output = new File(TEMP_DIRECTORY + FS + name);
-
-        if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionDex.getModel()))
-            Dex2Jar.dex2Jar(tempCopy, output);
-        else if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionEnjarify.getModel()))
-            Enjarify.apk2Jar(tempCopy, output);
-
         // create a new resource importer and copy the contents from it
-        container.copy(new ResourceContainerImporter(new ResourceContainer(output)).importAsZip().getContainer());
+        container.copy(Apk2Jar.obtainImpl().resourceContainerFromApk(tempCopy));
 
         BytecodeViewer.addResourceContainer(container);
     }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/resources/importing/impl/DEXResourceImporter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/resources/importing/impl/DEXResourceImporter.java
@@ -21,11 +21,9 @@ package the.bytecode.club.bytecodeviewer.resources.importing.impl;
 import org.apache.commons.io.FileUtils;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
 import the.bytecode.club.bytecodeviewer.resources.ResourceContainer;
-import the.bytecode.club.bytecodeviewer.resources.ResourceContainerImporter;
 import the.bytecode.club.bytecodeviewer.resources.importing.Importer;
-import the.bytecode.club.bytecodeviewer.util.Dex2Jar;
-import the.bytecode.club.bytecodeviewer.util.Enjarify;
 import the.bytecode.club.bytecodeviewer.util.MiscUtils;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Apk2Jar;
 
 import java.io.File;
 
@@ -47,16 +45,8 @@ public class DEXResourceImporter implements Importer
 
         ResourceContainer container = new ResourceContainer(tempCopy, file.getName());
 
-        String name = MiscUtils.getRandomizedName() + ".jar";
-        File output = new File(TEMP_DIRECTORY + FS + name);
-
-        if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionDex.getModel()))
-            Dex2Jar.dex2Jar(tempCopy, output);
-        else if (BytecodeViewer.viewer.apkConversionGroup.isSelected(BytecodeViewer.viewer.apkConversionEnjarify.getModel()))
-            Enjarify.apk2Jar(tempCopy, output);
-
         //create a new resource importer and copy the contents from it
-        container.copy(new ResourceContainerImporter(new ResourceContainer(output)).importAsZip().getContainer());
+        container.copy(Apk2Jar.obtainImpl().resourceContainerFromApk(tempCopy));
 
         BytecodeViewer.addResourceContainer(container);
     }

--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/SecurityMan.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/SecurityMan.java
@@ -25,6 +25,7 @@ import the.bytecode.club.bytecodeviewer.compilers.impl.JavaCompiler;
 import the.bytecode.club.bytecodeviewer.compilers.impl.KrakatauAssembler;
 import the.bytecode.club.bytecodeviewer.decompilers.impl.*;
 import the.bytecode.club.bytecodeviewer.resources.ExternalResources;
+import the.bytecode.club.bytecodeviewer.util.apk2Jar.Enjarify;
 
 import java.io.File;
 import java.io.FileDescriptor;

--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/apk2Jar/Apk2Jar.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/apk2Jar/Apk2Jar.java
@@ -1,0 +1,96 @@
+package the.bytecode.club.bytecodeviewer.util.apk2Jar;
+
+import the.bytecode.club.bytecodeviewer.BytecodeViewer;
+import the.bytecode.club.bytecodeviewer.gui.MainViewerGUI;
+import the.bytecode.club.bytecodeviewer.resources.ResourceContainer;
+import the.bytecode.club.bytecodeviewer.resources.ResourceContainerImporter;
+import the.bytecode.club.bytecodeviewer.util.MiscUtils;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.IOException;
+
+import static the.bytecode.club.bytecodeviewer.Constants.FS;
+import static the.bytecode.club.bytecodeviewer.Constants.TEMP_DIRECTORY;
+
+public abstract class Apk2Jar
+{
+
+    private static final Object workLock = new Object();
+
+    final public ResourceContainer resourceContainerFromApk(File inputApk) throws IOException {
+        synchronized (workLock) {
+            return resourceContainerFromApkImpl(inputApk);
+        }
+    }
+
+    protected abstract ResourceContainer resourceContainerFromApkImpl(File inputApk) throws IOException;
+
+    final protected File createTempJarFile()
+    {
+        String name = MiscUtils.getRandomizedName() + ".jar";
+        return new File(TEMP_DIRECTORY + FS + name);
+    }
+
+    final protected File createTempFolder()
+    {
+        String name = MiscUtils.getRandomizedName();
+        File folder = new File(TEMP_DIRECTORY + FS + name);
+        if (!folder.mkdir())
+        {
+            throw new RuntimeException("Failed to create temp folder: " + folder.getAbsolutePath());
+        }
+        return folder;
+    }
+
+    final protected ResourceContainer createResourceContainerFromJar(File output) throws IOException
+    {
+        return new ResourceContainerImporter(new ResourceContainer(output)).importAsZip().getContainer();
+    }
+
+    final protected ResourceContainer createResourceContainerFromFolder(File output) throws IOException
+    {
+        return new ResourceContainerImporter(new ResourceContainer(output)).importAsFolder().getContainer();
+    }
+
+    /**
+     * Translates dex classes from an apk to a folder
+     *
+     * @param input The apk file
+     * @return Folder with the .class files
+     */
+    final public File apk2Folder(File input) {
+        File folder = createTempFolder();
+        apk2FolderImpl(input, folder);
+        return folder;
+    }
+
+    /**
+     * Translates and repackage dex classes from an apk to a jar
+     *
+     * @param input The apk file
+     * @return The jar file
+     */
+    final public File apk2Jar(File input) {
+        File output = createTempJarFile();
+        synchronized (workLock) {
+            apk2JarImpl(input, output);
+        }
+        return output;
+    }
+
+    protected abstract void apk2JarImpl(File input, File output);
+    protected abstract void apk2FolderImpl(File input, File output);
+
+    public static Apk2Jar obtainImpl() {
+        MainViewerGUI viewer = BytecodeViewer.viewer;
+        ButtonGroup apkConversionGroup = viewer.apkConversionGroup;
+
+        if (apkConversionGroup.isSelected(viewer.apkConversionDex.getModel()))
+            return new Dex2Jar();
+        else if (apkConversionGroup.isSelected(viewer.apkConversionEnjarify.getModel()))
+            return new Enjarify();
+
+        throw new RuntimeException("Unknown implementation");
+    }
+}

--- a/src/main/java/the/bytecode/club/bytecodeviewer/util/apk2Jar/Dex2Jar.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/util/apk2Jar/Dex2Jar.java
@@ -16,7 +16,7 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  ***************************************************************************/
 
-package the.bytecode.club.bytecodeviewer.util;
+package the.bytecode.club.bytecodeviewer.util.apk2Jar;
 
 import com.googlecode.d2j.DexException;
 import com.googlecode.d2j.Method;
@@ -26,8 +26,10 @@ import com.googlecode.d2j.node.DexMethodNode;
 import com.googlecode.dex2jar.tools.Jar2Dex;
 import org.objectweb.asm.MethodVisitor;
 import the.bytecode.club.bytecodeviewer.BytecodeViewer;
+import the.bytecode.club.bytecodeviewer.resources.ResourceContainer;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * A simple wrapper for Dex2Jar.
@@ -35,16 +37,36 @@ import java.io.File;
  * @author Konloch
  */
 
-public class Dex2Jar
+public class Dex2Jar extends Apk2Jar
 {
+
+    @Override
+    protected ResourceContainer resourceContainerFromApkImpl(File inputApk) throws IOException
+    {
+        File tempFolder = createTempFolder();
+        dex2File(inputApk, tempFolder);
+        return createResourceContainerFromFolder(tempFolder);
+    }
+
+    @Override
+    public void apk2JarImpl(File input, File output)
+    {
+        dex2File(input, output);
+    }
+
+    @Override
+    protected void apk2FolderImpl(File input, File output)
+    {
+        dex2File(input, output);
+    }
 
     /**
      * Converts a .apk or .dex to .jar
      *
      * @param input  the input .apk or .dex file
-     * @param output the output .jar file
+     * @param output the output .jar file or folder
      */
-    public static synchronized void dex2Jar(File input, File output)
+    private static void dex2File(File input, File output)
     {
         try
         {


### PR DESCRIPTION
Hi,

This patch removes the unnecessary compression/decompression of the jar files when using the Dex2Jar. The Dex2Jar can simply write the jvm classes to a folder.