### PR TITLE
Plugin Writer, Fix unexpected text direction behavior

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginWriter.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/plugin/PluginWriter.java
@@ -91,8 +91,6 @@ public class PluginWriter extends JFrame
         area.setOnCtrlS(this::save);
         area.setText(content);
         area.setCaretPosition(0);
-        DefaultCaret caret = (DefaultCaret)area.getCaret();
-        caret.setUpdatePolicy(DefaultCaret.NEVER_UPDATE);
         SyntaxLanguage.setLanguage(area, pluginName);
         content = null;
 


### PR DESCRIPTION
These usages break text direction, switching to right-to-left (RTL) instead of the expected left-to-right (LTR).

area.setCaretPosition(0); does the same and is already in place.

Tested on my side and this resolved the following issue
#549 