### PR TITLE
fix: prevent NPE by adding null check for JFileChooser initialization

### DIFF
--- a/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/FileChooser.java
+++ b/src/main/java/the/bytecode/club/bytecodeviewer/gui/components/FileChooser.java
@@ -46,6 +46,11 @@ public class FileChooser
     public static JFileChooser create(boolean skipFileFilter, File file, String title, String description, String... extensions) throws ExecutionException, InterruptedException
     {
         JFileChooser chooser = SINGLETON.get();
+        if (chooser == null) {
+            System.err.println("Error: JFileChooser not initialized properly — skipping export.");
+            return null;
+        }
+
 
         Set<String> extensionSet = new HashSet<>(Arrays.asList(extensions));
 


### PR DESCRIPTION
This pull request fixes a potential NullPointerException that occurs when trying to use “Save as” or “Decompile and save” in Bytecode Viewer.

Cause:
The JFileChooser initialization could fail due to theme delegate issues in DarkLaf, leading to a null reference during export.

Fix:
Added a defensive null-check in FileChooser.create() to ensure the program safely handles the case where JFileChooser fails to initialize, instead of crashing.

Impact:

Prevents application crashes during export on certain Windows setups.

Improves stability for users on Java 21 and DarkLaf theme configurations.

Linked Issue:
Fixes #559